### PR TITLE
AirysDark-AI: add per-type PROBE workflows

### DIFF
--- a/.github/workflows/AirysDark-AI_prob_android.yml
+++ b/.github/workflows/AirysDark-AI_prob_android.yml
@@ -2,7 +2,7 @@ name: AirysDark-AI — Probe Android
 
 on:
   workflow_dispatch: {}
-  push: { branches: ["**"] }
+  push: "**"
 
 permissions:
   contents: write
@@ -58,7 +58,7 @@ jobs:
 
           on:
             workflow_dispatch: {}
-            push: { branches: ["**"] }
+            push: "**"
             pull_request: {}
 
           jobs:

--- a/.github/workflows/AirysDark-AI_prob_cmake.yml
+++ b/.github/workflows/AirysDark-AI_prob_cmake.yml
@@ -2,7 +2,7 @@ name: AirysDark-AI — Probe Cmake
 
 on:
   workflow_dispatch: {}
-  push: { branches: ["**"] }
+  push: "**"
 
 permissions:
   contents: write
@@ -51,7 +51,7 @@ jobs:
 
           on:
             workflow_dispatch: {}
-            push: { branches: ["**"] }
+            push: "**"
             pull_request: {}
 
           jobs:

--- a/.github/workflows/AirysDark-AI_prob_linux.yml
+++ b/.github/workflows/AirysDark-AI_prob_linux.yml
@@ -2,7 +2,7 @@ name: AirysDark-AI — Probe Linux
 
 on:
   workflow_dispatch: {}
-  push: { branches: ["**"] }
+  push: "**"
 
 permissions:
   contents: write
@@ -55,7 +55,7 @@ jobs:
 
           on:
             workflow_dispatch: {}
-            push: { branches: ["**"] }
+            push: "**"
             pull_request: {}
 
           jobs:


### PR DESCRIPTION
This PR adds one **PROBE** workflow per detected build type.

How to proceed:
1) Merge this PR.
2) Run the desired "AirysDark-AI — Probe <Type>" workflow from Actions.
   - It will scan the entire repo, pick the correct BUILD_CMD.
   - It will then generate the final AI build workflow `.github/workflows/AirysDark-AI_<type>.yml`
     and open a second PR with that workflow.
3) Merge the second PR to enable the final build+AI workflow for that type.

Notes:
- These probe workflows use the canonical tools:
  https://github.com/AirysDark-AI/AirysDark-AI_builder/tree/main/tools
- Ensure you set `BOT_TOKEN` (a PAT with `repo` + `workflow` scopes) in repo Secrets.