### PR TITLE
AirysDark-AI: add per-type PROBE workflows

### DIFF
--- a/.github/workflows/AirysDark-AI_prob_android.yml
+++ b/.github/workflows/AirysDark-AI_prob_android.yml
@@ -1,0 +1,199 @@
+name: AirysDark-AI — Probe Android
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "**"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+      - run: pip install requests
+
+      - name: Ensure AirysDark-AI tools (detector, probe, builder)
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p tools
+          BASE_URL="https://raw.githubusercontent.com/AirysDark-AI/AirysDark-AI_builder/main/tools"
+          curl -fL "$BASE_URL/AirysDark-AI_detector.py" -o tools/AirysDark-AI_detector.py
+          curl -fL "$BASE_URL/AirysDark-AI_probe.py"     -o tools/AirysDark-AI_probe.py
+          curl -fL "$BASE_URL/AirysDark-AI_builder.py"  -o tools/AirysDark-AI_builder.py
+          ls -la tools
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+      - uses: android-actions/setup-android@v3
+      - run: yes | sdkmanager --licenses
+      - run: sdkmanager "platform-tools" "platforms;android-34" "build-tools;34.0.0"
+      - name: Probe build command
+        id: probe
+        shell: bash
+        run: |
+          set -euxo pipefail
+          python3 tools/AirysDark-AI_probe.py --type "android" | tee /tmp/probe.out
+          CMD=$(grep -E '^BUILD_CMD=' /tmp/probe.out | sed 's/^BUILD_CMD=//')
+          echo "BUILD_CMD=$CMD" >> "$GITHUB_OUTPUT"
+
+      - name: Generate final workflow .github/workflows/AirysDark-AI_android.yml
+        shell: bash
+        env:
+          BUILD_CMD: "${{ steps.probe.outputs.BUILD_CMD }}"
+        run: |
+          set -euo pipefail
+          mkdir -p .github/workflows
+          cat > .github/workflows/AirysDark-AI_android.yml <<'YAML'
+          name: AirysDark-AI — Android (generated)
+
+          on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "**"
+
+          jobs:
+            build:
+              runs-on: ubuntu-latest
+              permissions:
+                contents: write
+                pull-requests: write
+              steps:
+                - uses: actions/checkout@v4
+                  with: { fetch-depth: 0 }
+
+                - uses: actions/setup-python@v5
+                  with: { python-version: "3.11" }
+                - run: pip install requests
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+      - uses: android-actions/setup-android@v3
+      - run: yes | sdkmanager --licenses
+      - run: sdkmanager "platform-tools" "platforms;android-34" "build-tools;34.0.0"
+                - name: Ensure AirysDark-AI tools (detector, builder)
+                  shell: bash
+                  run: |
+                    set -euo pipefail
+                    mkdir -p tools
+                    BASE_URL="https://raw.githubusercontent.com/AirysDark-AI/AirysDark-AI_builder/main/tools"
+                    [ -f tools/AirysDark-AI_detector.py ] || curl -fL "$BASE_URL/AirysDark-AI_detector.py" -o tools/AirysDark-AI_detector.py
+                    [ -f tools/AirysDark-AI_builder.py ]  || curl -fL "$BASE_URL/AirysDark-AI_builder.py"  -o tools/AirysDark-AI_builder.py
+
+                - name: Build (capture)
+                  id: build
+                  shell: bash
+                  run: |
+                    set -euxo pipefail
+                    CMD="$BUILD_CMD"
+                    echo "BUILD_CMD=$CMD" >> "$GITHUB_OUTPUT"
+                    set +e; bash -lc "$CMD" | tee build.log; EXIT=$?; set -e
+                    echo "EXIT_CODE=$EXIT" >> "$GITHUB_OUTPUT"
+                    [ -s build.log ] || echo "(no build output captured)" > build.log
+                    exit 0
+                  continue-on-error: true
+
+                - name: Upload build log
+                  if: always()
+                  uses: actions/upload-artifact@v4
+                  with:
+                    name: android-build-log
+                    path: build.log
+                    if-no-files-found: warn
+                    retention-days: 7
+
+                # --- AI auto-fix (OpenAI → llama.cpp) ---
+                - name: Build llama.cpp (CMake, no CURL, in temp)
+                  if: always() && ${{ steps.build.outputs.EXIT_CODE }} != '0'
+                  run: |
+                    set -euxo pipefail
+                    TMP="${{ runner.temp }}"
+                    cd "$TMP"
+                    rm -rf llama.cpp
+                    git clone --depth=1 https://github.com/ggml-org/llama.cpp
+                    cd llama.cpp
+                    cmake -S . -B build -D CMAKE_BUILD_TYPE=Release -DLLAMA_CURL=OFF
+                    cmake --build build -j
+                    echo "LLAMA_CPP_BIN=$PWD/build/bin/llama-cli" >> $GITHUB_ENV
+
+                - name: Fetch GGUF model (TinyLlama)
+                  if: always() && ${{ steps.build.outputs.EXIT_CODE }} != '0'
+                  run: |
+                    mkdir -p models
+                    curl -L -o models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf \
+                      https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf
+
+                - name: Attempt AI auto-fix (OpenAI → llama fallback)
+                  if: always() && ${{ steps.build.outputs.EXIT_CODE }} != '0'
+                  env:
+                    PROVIDER: openai
+                    FALLBACK_PROVIDER: llama
+                    OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+                    OPENAI_MODEL: ${{ vars.OPENAI_MODEL || 'gpt-4o-mini' }}
+                    MODEL_PATH: models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf
+                    AI_BUILDER_ATTEMPTS: "3"
+                    BUILD_CMD: ${{ steps.build.outputs.BUILD_CMD }}
+                  run: python3 tools/AirysDark-AI_builder.py || true
+
+                - name: Upload AI patch (if any)
+                  if: always()
+                  uses: actions/upload-artifact@v4
+                  with:
+                    name: android-ai-patch
+                    path: .pre_ai_fix.patch
+                    if-no-files-found: ignore
+                    retention-days: 7
+
+                - name: Check for changes
+                  id: diff
+                  run: |
+                    git add -A
+                    if git diff --cached --quiet; then
+                      echo "changed=false" >> "$GITHUB_OUTPUT"
+                    else:
+                      echo "changed=true" >> "$GITHUB_OUTPUT"
+                    fi
+
+                - name: Create PR with AI fixes
+                  if: ${{ steps.diff.outputs.changed }} == 'true'
+                  uses: peter-evans/create-pull-request@v6
+                  with:
+                    token: ${{ secrets.BOT_TOKEN }}
+                    branch: ai/airysdark-ai-autofix-android
+                    commit-message: "chore: AirysDark-AI auto-fix (android)"
+                    title: "AirysDark-AI: automated build fix (android)"
+                    body: |
+                      This PR was opened automatically by a generated workflow after a failed build.
+                      - Build command: ${{ steps.build.outputs.BUILD_CMD }}
+                      - Captured the failing build log
+                      - Proposed a minimal fix via AI
+                      - Committed the changes for review
+                    labels: automation, ci
+          YAML
+
+      - name: Create PR with generated final workflow
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.BOT_TOKEN }}
+          branch: ai/airysdark-ai-workflow-android
+          commit-message: "chore: add AirysDark-AI_android workflow (probed)"
+          title: "AirysDark-AI: add android workflow (from probe)"
+          body: |
+            This PR adds the final android AI build workflow, generated by the probe run.
+            - Probed command: ${{ steps.probe.outputs.BUILD_CMD }}
+            - Next: merge this PR, then run “AirysDark-AI — Android (generated)”
+          labels: automation, ci

--- a/.github/workflows/AirysDark-AI_prob_cmake.yml
+++ b/.github/workflows/AirysDark-AI_prob_cmake.yml
@@ -1,0 +1,185 @@
+name: AirysDark-AI — Probe Cmake
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "**"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+      - run: pip install requests
+
+      - name: Ensure AirysDark-AI tools (detector, probe, builder)
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p tools
+          BASE_URL="https://raw.githubusercontent.com/AirysDark-AI/AirysDark-AI_builder/main/tools"
+          curl -fL "$BASE_URL/AirysDark-AI_detector.py" -o tools/AirysDark-AI_detector.py
+          curl -fL "$BASE_URL/AirysDark-AI_probe.py"     -o tools/AirysDark-AI_probe.py
+          curl -fL "$BASE_URL/AirysDark-AI_builder.py"  -o tools/AirysDark-AI_builder.py
+          ls -la tools
+
+      - name: Probe build command
+        id: probe
+        shell: bash
+        run: |
+          set -euxo pipefail
+          python3 tools/AirysDark-AI_probe.py --type "cmake" | tee /tmp/probe.out
+          CMD=$(grep -E '^BUILD_CMD=' /tmp/probe.out | sed 's/^BUILD_CMD=//')
+          echo "BUILD_CMD=$CMD" >> "$GITHUB_OUTPUT"
+
+      - name: Generate final workflow .github/workflows/AirysDark-AI_cmake.yml
+        shell: bash
+        env:
+          BUILD_CMD: "${{ steps.probe.outputs.BUILD_CMD }}"
+        run: |
+          set -euo pipefail
+          mkdir -p .github/workflows
+          cat > .github/workflows/AirysDark-AI_cmake.yml <<'YAML'
+          name: AirysDark-AI — Cmake (generated)
+
+          on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "**"
+
+          jobs:
+            build:
+              runs-on: ubuntu-latest
+              permissions:
+                contents: write
+                pull-requests: write
+              steps:
+                - uses: actions/checkout@v4
+                  with: { fetch-depth: 0 }
+
+                - uses: actions/setup-python@v5
+                  with: { python-version: "3.11" }
+                - run: pip install requests
+
+                - name: Ensure AirysDark-AI tools (detector, builder)
+                  shell: bash
+                  run: |
+                    set -euo pipefail
+                    mkdir -p tools
+                    BASE_URL="https://raw.githubusercontent.com/AirysDark-AI/AirysDark-AI_builder/main/tools"
+                    [ -f tools/AirysDark-AI_detector.py ] || curl -fL "$BASE_URL/AirysDark-AI_detector.py" -o tools/AirysDark-AI_detector.py
+                    [ -f tools/AirysDark-AI_builder.py ]  || curl -fL "$BASE_URL/AirysDark-AI_builder.py"  -o tools/AirysDark-AI_builder.py
+
+                - name: Build (capture)
+                  id: build
+                  shell: bash
+                  run: |
+                    set -euxo pipefail
+                    CMD="$BUILD_CMD"
+                    echo "BUILD_CMD=$CMD" >> "$GITHUB_OUTPUT"
+                    set +e; bash -lc "$CMD" | tee build.log; EXIT=$?; set -e
+                    echo "EXIT_CODE=$EXIT" >> "$GITHUB_OUTPUT"
+                    [ -s build.log ] || echo "(no build output captured)" > build.log
+                    exit 0
+                  continue-on-error: true
+
+                - name: Upload build log
+                  if: always()
+                  uses: actions/upload-artifact@v4
+                  with:
+                    name: cmake-build-log
+                    path: build.log
+                    if-no-files-found: warn
+                    retention-days: 7
+
+                # --- AI auto-fix (OpenAI → llama.cpp) ---
+                - name: Build llama.cpp (CMake, no CURL, in temp)
+                  if: always() && ${{ steps.build.outputs.EXIT_CODE }} != '0'
+                  run: |
+                    set -euxo pipefail
+                    TMP="${{ runner.temp }}"
+                    cd "$TMP"
+                    rm -rf llama.cpp
+                    git clone --depth=1 https://github.com/ggml-org/llama.cpp
+                    cd llama.cpp
+                    cmake -S . -B build -D CMAKE_BUILD_TYPE=Release -DLLAMA_CURL=OFF
+                    cmake --build build -j
+                    echo "LLAMA_CPP_BIN=$PWD/build/bin/llama-cli" >> $GITHUB_ENV
+
+                - name: Fetch GGUF model (TinyLlama)
+                  if: always() && ${{ steps.build.outputs.EXIT_CODE }} != '0'
+                  run: |
+                    mkdir -p models
+                    curl -L -o models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf \
+                      https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf
+
+                - name: Attempt AI auto-fix (OpenAI → llama fallback)
+                  if: always() && ${{ steps.build.outputs.EXIT_CODE }} != '0'
+                  env:
+                    PROVIDER: openai
+                    FALLBACK_PROVIDER: llama
+                    OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+                    OPENAI_MODEL: ${{ vars.OPENAI_MODEL || 'gpt-4o-mini' }}
+                    MODEL_PATH: models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf
+                    AI_BUILDER_ATTEMPTS: "3"
+                    BUILD_CMD: ${{ steps.build.outputs.BUILD_CMD }}
+                  run: python3 tools/AirysDark-AI_builder.py || true
+
+                - name: Upload AI patch (if any)
+                  if: always()
+                  uses: actions/upload-artifact@v4
+                  with:
+                    name: cmake-ai-patch
+                    path: .pre_ai_fix.patch
+                    if-no-files-found: ignore
+                    retention-days: 7
+
+                - name: Check for changes
+                  id: diff
+                  run: |
+                    git add -A
+                    if git diff --cached --quiet; then
+                      echo "changed=false" >> "$GITHUB_OUTPUT"
+                    else:
+                      echo "changed=true" >> "$GITHUB_OUTPUT"
+                    fi
+
+                - name: Create PR with AI fixes
+                  if: ${{ steps.diff.outputs.changed }} == 'true'
+                  uses: peter-evans/create-pull-request@v6
+                  with:
+                    token: ${{ secrets.BOT_TOKEN }}
+                    branch: ai/airysdark-ai-autofix-cmake
+                    commit-message: "chore: AirysDark-AI auto-fix (cmake)"
+                    title: "AirysDark-AI: automated build fix (cmake)"
+                    body: |
+                      This PR was opened automatically by a generated workflow after a failed build.
+                      - Build command: ${{ steps.build.outputs.BUILD_CMD }}
+                      - Captured the failing build log
+                      - Proposed a minimal fix via AI
+                      - Committed the changes for review
+                    labels: automation, ci
+          YAML
+
+      - name: Create PR with generated final workflow
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.BOT_TOKEN }}
+          branch: ai/airysdark-ai-workflow-cmake
+          commit-message: "chore: add AirysDark-AI_cmake workflow (probed)"
+          title: "AirysDark-AI: add cmake workflow (from probe)"
+          body: |
+            This PR adds the final cmake AI build workflow, generated by the probe run.
+            - Probed command: ${{ steps.probe.outputs.BUILD_CMD }}
+            - Next: merge this PR, then run “AirysDark-AI — Cmake (generated)”
+          labels: automation, ci

--- a/.github/workflows/AirysDark-AI_prob_linux.yml
+++ b/.github/workflows/AirysDark-AI_prob_linux.yml
@@ -1,0 +1,193 @@
+name: AirysDark-AI — Probe Linux
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "**"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+      - run: pip install requests
+
+      - name: Ensure AirysDark-AI tools (detector, probe, builder)
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p tools
+          BASE_URL="https://raw.githubusercontent.com/AirysDark-AI/AirysDark-AI_builder/main/tools"
+          curl -fL "$BASE_URL/AirysDark-AI_detector.py" -o tools/AirysDark-AI_detector.py
+          curl -fL "$BASE_URL/AirysDark-AI_probe.py"     -o tools/AirysDark-AI_probe.py
+          curl -fL "$BASE_URL/AirysDark-AI_builder.py"  -o tools/AirysDark-AI_builder.py
+          ls -la tools
+
+      - name: Install Meson & Ninja (Linux only)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y meson ninja-build pkg-config
+      - name: Probe build command
+        id: probe
+        shell: bash
+        run: |
+          set -euxo pipefail
+          python3 tools/AirysDark-AI_probe.py --type "linux" | tee /tmp/probe.out
+          CMD=$(grep -E '^BUILD_CMD=' /tmp/probe.out | sed 's/^BUILD_CMD=//')
+          echo "BUILD_CMD=$CMD" >> "$GITHUB_OUTPUT"
+
+      - name: Generate final workflow .github/workflows/AirysDark-AI_linux.yml
+        shell: bash
+        env:
+          BUILD_CMD: "${{ steps.probe.outputs.BUILD_CMD }}"
+        run: |
+          set -euo pipefail
+          mkdir -p .github/workflows
+          cat > .github/workflows/AirysDark-AI_linux.yml <<'YAML'
+          name: AirysDark-AI — Linux (generated)
+
+          on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "**"
+
+          jobs:
+            build:
+              runs-on: ubuntu-latest
+              permissions:
+                contents: write
+                pull-requests: write
+              steps:
+                - uses: actions/checkout@v4
+                  with: { fetch-depth: 0 }
+
+                - uses: actions/setup-python@v5
+                  with: { python-version: "3.11" }
+                - run: pip install requests
+
+      - name: Install Meson & Ninja (Linux only)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y meson ninja-build pkg-config
+                - name: Ensure AirysDark-AI tools (detector, builder)
+                  shell: bash
+                  run: |
+                    set -euo pipefail
+                    mkdir -p tools
+                    BASE_URL="https://raw.githubusercontent.com/AirysDark-AI/AirysDark-AI_builder/main/tools"
+                    [ -f tools/AirysDark-AI_detector.py ] || curl -fL "$BASE_URL/AirysDark-AI_detector.py" -o tools/AirysDark-AI_detector.py
+                    [ -f tools/AirysDark-AI_builder.py ]  || curl -fL "$BASE_URL/AirysDark-AI_builder.py"  -o tools/AirysDark-AI_builder.py
+
+                - name: Build (capture)
+                  id: build
+                  shell: bash
+                  run: |
+                    set -euxo pipefail
+                    CMD="$BUILD_CMD"
+                    echo "BUILD_CMD=$CMD" >> "$GITHUB_OUTPUT"
+                    set +e; bash -lc "$CMD" | tee build.log; EXIT=$?; set -e
+                    echo "EXIT_CODE=$EXIT" >> "$GITHUB_OUTPUT"
+                    [ -s build.log ] || echo "(no build output captured)" > build.log
+                    exit 0
+                  continue-on-error: true
+
+                - name: Upload build log
+                  if: always()
+                  uses: actions/upload-artifact@v4
+                  with:
+                    name: linux-build-log
+                    path: build.log
+                    if-no-files-found: warn
+                    retention-days: 7
+
+                # --- AI auto-fix (OpenAI → llama.cpp) ---
+                - name: Build llama.cpp (CMake, no CURL, in temp)
+                  if: always() && ${{ steps.build.outputs.EXIT_CODE }} != '0'
+                  run: |
+                    set -euxo pipefail
+                    TMP="${{ runner.temp }}"
+                    cd "$TMP"
+                    rm -rf llama.cpp
+                    git clone --depth=1 https://github.com/ggml-org/llama.cpp
+                    cd llama.cpp
+                    cmake -S . -B build -D CMAKE_BUILD_TYPE=Release -DLLAMA_CURL=OFF
+                    cmake --build build -j
+                    echo "LLAMA_CPP_BIN=$PWD/build/bin/llama-cli" >> $GITHUB_ENV
+
+                - name: Fetch GGUF model (TinyLlama)
+                  if: always() && ${{ steps.build.outputs.EXIT_CODE }} != '0'
+                  run: |
+                    mkdir -p models
+                    curl -L -o models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf \
+                      https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf
+
+                - name: Attempt AI auto-fix (OpenAI → llama fallback)
+                  if: always() && ${{ steps.build.outputs.EXIT_CODE }} != '0'
+                  env:
+                    PROVIDER: openai
+                    FALLBACK_PROVIDER: llama
+                    OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+                    OPENAI_MODEL: ${{ vars.OPENAI_MODEL || 'gpt-4o-mini' }}
+                    MODEL_PATH: models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf
+                    AI_BUILDER_ATTEMPTS: "3"
+                    BUILD_CMD: ${{ steps.build.outputs.BUILD_CMD }}
+                  run: python3 tools/AirysDark-AI_builder.py || true
+
+                - name: Upload AI patch (if any)
+                  if: always()
+                  uses: actions/upload-artifact@v4
+                  with:
+                    name: linux-ai-patch
+                    path: .pre_ai_fix.patch
+                    if-no-files-found: ignore
+                    retention-days: 7
+
+                - name: Check for changes
+                  id: diff
+                  run: |
+                    git add -A
+                    if git diff --cached --quiet; then
+                      echo "changed=false" >> "$GITHUB_OUTPUT"
+                    else:
+                      echo "changed=true" >> "$GITHUB_OUTPUT"
+                    fi
+
+                - name: Create PR with AI fixes
+                  if: ${{ steps.diff.outputs.changed }} == 'true'
+                  uses: peter-evans/create-pull-request@v6
+                  with:
+                    token: ${{ secrets.BOT_TOKEN }}
+                    branch: ai/airysdark-ai-autofix-linux
+                    commit-message: "chore: AirysDark-AI auto-fix (linux)"
+                    title: "AirysDark-AI: automated build fix (linux)"
+                    body: |
+                      This PR was opened automatically by a generated workflow after a failed build.
+                      - Build command: ${{ steps.build.outputs.BUILD_CMD }}
+                      - Captured the failing build log
+                      - Proposed a minimal fix via AI
+                      - Committed the changes for review
+                    labels: automation, ci
+          YAML
+
+      - name: Create PR with generated final workflow
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.BOT_TOKEN }}
+          branch: ai/airysdark-ai-workflow-linux
+          commit-message: "chore: add AirysDark-AI_linux workflow (probed)"
+          title: "AirysDark-AI: add linux workflow (from probe)"
+          body: |
+            This PR adds the final linux AI build workflow, generated by the probe run.
+            - Probed command: ${{ steps.probe.outputs.BUILD_CMD }}
+            - Next: merge this PR, then run “AirysDark-AI — Linux (generated)”
+          labels: automation, ci

--- a/tools/AirysDark-AI_builder.py
+++ b/tools/AirysDark-AI_builder.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+import os, pathlib, textwrap, sys
+
+ROOT = pathlib.Path(os.getenv("PROJECT_DIR", ".")).resolve()
+WF = ROOT / ".github" / "workflows"
+WF.mkdir(parents=True, exist_ok=True)
+
+def exists_any(patterns):
+    for pat in patterns:
+        if list(ROOT.glob(pat)):
+            return True
+    return False
+
+def detect_types():
+    types = []
+    if (ROOT / "gradlew").exists() or exists_any(["**/gradlew", "**/build.gradle*", "**/settings.gradle*"]):
+        types.append("android")
+    if (ROOT / "CMakeLists.txt").exists() or exists_any(["**/CMakeLists.txt"]):
+        types.append("cmake")
+    if (ROOT / "package.json").exists():
+        types.append("node")
+    if (ROOT / "setup.py").exists() or (ROOT / "pyproject.toml").exists():
+        types.append("python")
+    if (ROOT / "Cargo.toml").exists():
+        types.append("rust")
+    if exists_any(["*.sln", "**/*.csproj", "**/*.fsproj"]):
+        types.append("dotnet")
+    if (ROOT / "pom.xml").exists():
+        types.append("maven")
+    if (ROOT / "pubspec.yaml").exists():
+        types.append("flutter")
+    if (ROOT / "go.mod").exists():
+        types.append("go")
+    if not types:
+        types.append("unknown")
+    return types
+
+BUILD_CMDS = {
+    "android": "./gradlew assembleDebug --stacktrace",
+    "cmake":   "cmake -S . -B build && cmake --build build -j",
+    "node":    "npm ci && npm run build --if-present",
+    "python":  "pip install -e . && pytest || python -m pytest",
+    "rust":    "cargo build --locked --all-targets --verbose",
+    "dotnet":  "dotnet restore && dotnet build -c Release",
+    "maven":   "mvn -B package --file pom.xml",
+    "flutter": "flutter build apk --debug",
+    "go":      "go build ./...",
+    "unknown": "echo 'No build system detected' && exit 1",
+}
+
+def setup_steps(ptype: str) -> str:
+    if ptype == "android":
+        return textwrap.dedent("""
+          - uses: actions/setup-java@v4
+            with: { distribution: temurin, java-version: "17" }
+          - uses: android-actions/setup-android@v3
+          - run: yes | sdkmanager --licenses
+          - run: sdkmanager "platform-tools" "platforms;android-34" "build-tools;34.0.0"
+        """)
+    if ptype == "node":
+        return textwrap.dedent("""
+          - uses: actions/setup-node@v4
+            with: { node-version: "20" }
+        """)
+    if ptype == "rust":
+        return textwrap.dedent("""
+          - uses: dtolnay/rust-toolchain@stable
+          - run: rustc --version && cargo --version
+        """)
+    if ptype == "dotnet":
+        return textwrap.dedent("""
+          - uses: actions/setup-dotnet@v4
+            with: { dotnet-version: "8.0.x" }
+          - run: dotnet --info
+        """)
+    if ptype == "maven":
+        return textwrap.dedent("""
+          - uses: actions/setup-java@v4
+            with: { distribution: temurin, java-version: "17" }
+          - run: mvn --version
+        """)
+    if ptype == "flutter":
+        return textwrap.dedent("""
+          - uses: subosito/flutter-action@v2
+            with: { flutter-version: "3.22.0" }
+          - run: flutter --version
+        """)
+    if ptype == "go":
+        return textwrap.dedent("""
+          - uses: actions/setup-go@v5
+            with: { go-version: "1.22" }
+          - run: go version
+        """)
+    return ""
+
+def common_ai():
+    return textwrap.dedent("""
+      - name: Build llama.cpp (CMake, no CURL)
+        run: |
+          git clone --depth=1 https://github.com/ggml-org/llama.cpp
+          cd llama.cpp
+          cmake -S . -B build -D CMAKE_BUILD_TYPE=Release -DLLAMA_CURL=OFF
+          cmake --build build -j
+          echo "LLAMA_CPP_BIN=$PWD/build/bin/llama-cli" >> $GITHUB_ENV
+
+      - name: Fetch GGUF model (TinyLlama)
+        run: |
+          mkdir -p models
+          curl -L -o models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf \\
+            https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf
+
+      - name: Attempt AI auto-fix (OpenAI → llama fallback)
+        if: always() && steps.build.outputs.EXIT_CODE != '0'
+        env:
+          PROVIDER: openai
+          FALLBACK_PROVIDER: llama
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_MODEL: ${{ vars.OPENAI_MODEL || 'gpt-4o-mini' }}
+          MODEL_PATH: models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf
+          AI_BUILDER_ATTEMPTS: "2"
+          BUILD_CMD: ${{ steps.build.outputs.BUILD_CMD }}
+        run: python3 tools/AirysDark-AI_builder.py || true
+    """)
+
+def write_workflow(ptype: str, cmd: str):
+    setup = setup_steps(ptype)
+    yaml = f"""
+    name: AirysDark-AI — {ptype.capitalize()} (generated)
+
+    on: [push, pull_request, workflow_dispatch]
+
+    jobs:
+      build:
+        runs-on: ubuntu-latest
+        permissions:
+          contents: write
+          pull-requests: write
+        steps:
+          - uses: actions/checkout@v4
+
+          - uses: actions/setup-python@v5
+            with: {{ python-version: "3.11" }}
+          - run: pip install requests
+{setup if setup.strip() else ""}
+          - name: Build (capture)
+            id: build
+            shell: bash
+            run: |
+              set -euxo pipefail
+              CMD="{cmd}"
+              echo "BUILD_CMD=$CMD" >> "$GITHUB_OUTPUT"
+              set +e; bash -lc "$CMD" | tee build.log; EXIT=$?; set -e
+              echo "EXIT_CODE=$EXIT" >> "$GITHUB_OUTPUT"
+              [ -f build.log ] || echo "(no build output captured)" > build.log
+              exit 0
+            continue-on-error: true
+{common_ai()}
+    """
+    out = WF / f"AirysDark-AI_{ptype}.yml"
+    out.write_text(textwrap.dedent(yaml))
+    print(f"✅ Generated: {out.name}")
+
+def main():
+    types = detect_types()
+    for t in types:
+        write_workflow(t, BUILD_CMDS[t])
+    print(f"Done. Generated {len(types)} workflow(s) in {WF}")
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/AirysDark-AI_detector.py
+++ b/tools/AirysDark-AI_detector.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+# AirysDark-AI_detector.py
+#
+# Scans *all files/dirs* in repo to detect build systems.
+# Adds:
+#   - CMake content-aware detection to also flag "linux" when the CMakeLists looks desktop-ish.
+#   - Folder-name hints (e.g., "linux", "android", "windows") to augment detection.
+# Writes one PROBE workflow per detected type:
+#   .github/workflows/AirysDark-AI_prob_<type>.yml
+#
+# Types it can emit probes for:
+#   android, cmake, linux, node, python, rust, dotnet, maven, flutter, go,
+#   bazel, scons, ninja, unknown
+
+import os
+import pathlib
+import textwrap
+import sys
+
+ROOT = pathlib.Path(os.getenv("PROJECT_DIR", ".")).resolve()
+WF = ROOT / ".github" / "workflows"
+WF.mkdir(parents=True, exist_ok=True)
+
+# ---------- Full-repo scan ----------
+def scan_all_files():
+    files = []
+    for root, dirs, filenames in os.walk(ROOT):
+        if ".git" in dirs:
+            dirs.remove(".git")
+        for fn in filenames:
+            p = pathlib.Path(root) / fn
+            try:
+                rel = p.relative_to(ROOT)
+            except Exception:
+                rel = p
+            files.append((fn.lower(), rel))
+    return files
+
+def read_text_safe(p: pathlib.Path) -> str:
+    try:
+        return (ROOT / p).read_text(errors="ignore")
+    except Exception:
+        return ""
+
+# ---------- Helpers: folder-name hints ----------
+def collect_dir_name_hints(files):
+    """
+    Return a set of lower-cased directory names seen anywhere in the repo.
+    Includes each path segment from the file paths (not just immediate parents).
+    """
+    names = set()
+    for _, rel in files:
+        for part in pathlib.Path(rel).parts:
+            names.add(part.lower())
+    return names
+
+# ---------- CMake classifier ----------
+ANDROID_HINTS = (
+    "android", "android_abi", "android_platform", "ndk", "cmake_android", "gradle", "externalnativebuild",
+    "find_library(log)", "log-lib", "loglib"
+)
+DESKTOP_HINTS = (
+    "add_executable", "pkgconfig", "find_package(", "threads", "pthread", "x11", "wayland", "gtk", "qt",
+    "set(cmake_system_name linux"
+)
+
+def cmakelists_flavor(cm_txt: str) -> str:
+    t = cm_txt.lower()
+    if any(h in t for h in ANDROID_HINTS):
+        return "android"
+    if any(h in t for h in DESKTOP_HINTS):
+        return "desktop"
+    return "desktop"
+
+def detect_types():
+    files = scan_all_files()
+    fnames = [n for n, _ in files]
+    rels   = [str(p).lower() for _, p in files]
+    dir_hints = collect_dir_name_hints(files)
+
+    types = []
+
+    # Folder-name hints first (broad signals even if build files are elsewhere)
+    if "linux" in dir_hints and "linux" not in types:
+        types.append("linux")
+    if "android" in dir_hints and "android" not in types:
+        types.append("android")
+    if "windows" in dir_hints and "windows" not in types:
+        types.append("windows")
+
+    # Android / Gradle
+    if ("gradlew" in fnames) or any("build.gradle" in n or "settings.gradle" in n for n in fnames):
+        if "android" not in types:
+            types.append("android")
+
+    # CMake (content-aware -> may also flag linux)
+    cmake_paths = [p for (n, p) in files if n == "cmakelists.txt"]
+    if cmake_paths and "cmake" not in types:
+        types.append("cmake")
+    if cmake_paths:
+        for p in cmake_paths:
+            txt = read_text_safe(p)
+            if cmakelists_flavor(txt) == "desktop" and "linux" not in types:
+                types.append("linux")
+
+    # Linux umbrella (Make / Meson / any *.mk)
+    if ("makefile" in fnames) or ("gnumakefile" in fnames) or ("meson.build" in fnames) or any(r.endswith(".mk") for r in rels):
+        if "linux" not in types:
+            types.append("linux")
+
+    # Node
+    if "package.json" in fnames and "node" not in types:
+        types.append("node")
+    # Python
+    if ("pyproject.toml" in fnames or "setup.py" in fnames) and "python" not in types:
+        types.append("python")
+    # Rust
+    if "cargo.toml" in fnames and "rust" not in types:
+        types.append("rust")
+    # .NET
+    if any(r.endswith(".sln") or r.endswith(".csproj") or r.endswith(".fsproj") for r in rels) and "dotnet" not in types:
+        types.append("dotnet")
+    # Maven
+    if "pom.xml" in fnames and "maven" not in types:
+        types.append("maven")
+    # Flutter
+    if "pubspec.yaml" in fnames and "flutter" not in types:
+        types.append("flutter")
+    # Go
+    if "go.mod" in fnames and "go" not in types:
+        types.append("go")
+    # Bazel
+    if any(n in ("workspace", "workspace.bazel", "module.bazel") for n in fnames) or \
+       any(os.path.basename(r) in ("build", "build.bazel") for r in rels):
+        if "bazel" not in types:
+            types.append("bazel")
+    # SCons
+    if "sconstruct" in fnames or "sconscript" in fnames:
+        if "scons" not in types:
+            types.append("scons")
+    # Ninja
+    if "build.ninja" in fnames and "ninja" not in types:
+        types.append("ninja")
+
+    if not types:
+        types.append("unknown")
+
+    # De-dupe preserve order
+    seen, out = set(), []
+    for t in types:
+        if t not in seen:
+            seen.add(t)
+            out.append(t)
+    return out
+
+# ---------- Type-specific setup (embedded into final workflow) ----------
+def setup_steps_inline(ptype: str) -> str:
+    if ptype == "android":
+        return textwrap.dedent("""
+          - uses: actions/setup-java@v4
+            with:
+              distribution: temurin
+              java-version: "17"
+          - uses: android-actions/setup-android@v3
+          - run: yes | sdkmanager --licenses
+          - run: sdkmanager "platform-tools" "platforms;android-34" "build-tools;34.0.0"
+        """)
+    if ptype == "node":
+        return textwrap.dedent("""
+          - uses: actions/setup-node@v4
+            with: { node-version: "20" }
+        """)
+    if ptype == "rust":
+        return textwrap.dedent("""
+          - uses: dtolnay/rust-toolchain@stable
+          - run: rustc --version && cargo --version
+        """)
+    if ptype == "dotnet":
+        return textwrap.dedent("""
+          - uses: actions/setup-dotnet@v4
+            with: { dotnet-version: "8.0.x" }
+          - run: dotnet --info
+        """)
+    if ptype == "maven":
+        return textwrap.dedent("""
+          - uses: actions/setup-java@v4
+            with:
+              distribution: temurin
+              java-version: "17"
+          - run: mvn --version
+        """)
+    if ptype == "flutter":
+        return textwrap.dedent("""
+          - uses: subosito/flutter-action@v2
+            with: { flutter-version: "3.22.0" }
+          - run: flutter --version
+        """)
+    if ptype == "go":
+        return textwrap.dedent("""
+          - uses: actions/setup-go@v5
+            with: { go-version: "1.22" }
+          - run: go version
+        """)
+    if ptype == "linux":
+        return textwrap.dedent("""
+          - name: Install Meson & Ninja (Linux only)
+            run: |
+              sudo apt-get update
+              sudo apt-get install -y meson ninja-build pkg-config
+        """)
+    if ptype == "bazel":
+        return textwrap.dedent("""
+          - uses: bazelbuild/setup-bazelisk@v3
+        """)
+    if ptype == "scons":
+        return textwrap.dedent("""
+          - name: Install SCons
+            run: |
+              sudo apt-get update
+              sudo apt-get install -y scons
+        """)
+    if ptype == "ninja":
+        return textwrap.dedent("""
+          - name: Ensure Ninja
+            run: |
+              sudo apt-get update
+              sudo apt-get install -y ninja-build
+        """)
+    # cmake/python/unknown: setup-python only
+    return ""
+
+# ---------- PROBE workflow generator (brace-safe) ----------
+def write_probe_workflow_for_type(ptype: str):
+    setup_inline = setup_steps_inline(ptype)
+
+    # Build the YAML using placeholders; then replace them so ${{ }} is literal.
+    tmpl = r"""
+name: AirysDark-AI — Probe __PTYPE_CAP__
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "**"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+      - run: pip install requests
+
+      - name: Ensure AirysDark-AI tools (detector, probe, builder)
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p tools
+          BASE_URL="https://raw.githubusercontent.com/AirysDark-AI/AirysDark-AI_builder/main/tools"
+          curl -fL "$BASE_URL/AirysDark-AI_detector.py" -o tools/AirysDark-AI_detector.py
+          curl -fL "$BASE_URL/AirysDark-AI_probe.py"     -o tools/AirysDark-AI_probe.py
+          curl -fL "$BASE_URL/AirysDark-AI_builder.py"  -o tools/AirysDark-AI_builder.py
+          ls -la tools
+__SETUP_INLINE__
+      - name: Probe build command
+        id: probe
+        shell: bash
+        run: |
+          set -euxo pipefail
+          python3 tools/AirysDark-AI_probe.py --type "__PTYPE__" | tee /tmp/probe.out
+          CMD=$(grep -E '^BUILD_CMD=' /tmp/probe.out | sed 's/^BUILD_CMD=//')
+          echo "BUILD_CMD=$CMD" >> "$GITHUB_OUTPUT"
+
+      - name: Generate final workflow .github/workflows/AirysDark-AI___PTYPE__.yml
+        shell: bash
+        env:
+          BUILD_CMD: "__GHA__ steps.probe.outputs.BUILD_CMD __GHA_END__"
+        run: |
+          set -euo pipefail
+          mkdir -p .github/workflows
+          cat > .github/workflows/AirysDark-AI___PTYPE__.yml <<'YAML'
+          name: AirysDark-AI — __PTYPE_CAP__ (generated)
+
+          on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "**"
+
+          jobs:
+            build:
+              runs-on: ubuntu-latest
+              permissions:
+                contents: write
+                pull-requests: write
+              steps:
+                - uses: actions/checkout@v4
+                  with: { fetch-depth: 0 }
+
+                - uses: actions/setup-python@v5
+                  with: { python-version: "3.11" }
+                - run: pip install requests
+__SETUP_INLINE__
+                - name: Ensure AirysDark-AI tools (detector, builder)
+                  shell: bash
+                  run: |
+                    set -euo pipefail
+                    mkdir -p tools
+                    BASE_URL="https://raw.githubusercontent.com/AirysDark-AI/AirysDark-AI_builder/main/tools"
+                    [ -f tools/AirysDark-AI_detector.py ] || curl -fL "$BASE_URL/AirysDark-AI_detector.py" -o tools/AirysDark-AI_detector.py
+                    [ -f tools/AirysDark-AI_builder.py ]  || curl -fL "$BASE_URL/AirysDark-AI_builder.py"  -o tools/AirysDark-AI_builder.py
+
+                - name: Build (capture)
+                  id: build
+                  shell: bash
+                  run: |
+                    set -euxo pipefail
+                    CMD="$BUILD_CMD"
+                    echo "BUILD_CMD=$CMD" >> "$GITHUB_OUTPUT"
+                    set +e; bash -lc "$CMD" | tee build.log; EXIT=$?; set -e
+                    echo "EXIT_CODE=$EXIT" >> "$GITHUB_OUTPUT"
+                    [ -s build.log ] || echo "(no build output captured)" > build.log
+                    exit 0
+                  continue-on-error: true
+
+                - name: Upload build log
+                  if: always()
+                  uses: actions/upload-artifact@v4
+                  with:
+                    name: __PTYPE__-build-log
+                    path: build.log
+                    if-no-files-found: warn
+                    retention-days: 7
+
+                # --- AI auto-fix (OpenAI → llama.cpp) ---
+                - name: Build llama.cpp (CMake, no CURL, in temp)
+                  if: always() && __GHA__ steps.build.outputs.EXIT_CODE __GHA_END__ != '0'
+                  run: |
+                    set -euxo pipefail
+                    TMP="__GHA__ runner.temp __GHA_END__"
+                    cd "$TMP"
+                    rm -rf llama.cpp
+                    git clone --depth=1 https://github.com/ggml-org/llama.cpp
+                    cd llama.cpp
+                    cmake -S . -B build -D CMAKE_BUILD_TYPE=Release -DLLAMA_CURL=OFF
+                    cmake --build build -j
+                    echo "LLAMA_CPP_BIN=$PWD/build/bin/llama-cli" >> $GITHUB_ENV
+
+                - name: Fetch GGUF model (TinyLlama)
+                  if: always() && __GHA__ steps.build.outputs.EXIT_CODE __GHA_END__ != '0'
+                  run: |
+                    mkdir -p models
+                    curl -L -o models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf \
+                      https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf
+
+                - name: Attempt AI auto-fix (OpenAI → llama fallback)
+                  if: always() && __GHA__ steps.build.outputs.EXIT_CODE __GHA_END__ != '0'
+                  env:
+                    PROVIDER: openai
+                    FALLBACK_PROVIDER: llama
+                    OPENAI_API_KEY: __GHA__ secrets.OPENAI_API_KEY __GHA_END__
+                    OPENAI_MODEL: __GHA__ vars.OPENAI_MODEL || 'gpt-4o-mini' __GHA_END__
+                    MODEL_PATH: models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf
+                    AI_BUILDER_ATTEMPTS: "3"
+                    BUILD_CMD: __GHA__ steps.build.outputs.BUILD_CMD __GHA_END__
+                  run: python3 tools/AirysDark-AI_builder.py || true
+
+                - name: Upload AI patch (if any)
+                  if: always()
+                  uses: actions/upload-artifact@v4
+                  with:
+                    name: __PTYPE__-ai-patch
+                    path: .pre_ai_fix.patch
+                    if-no-files-found: ignore
+                    retention-days: 7
+
+                - name: Check for changes
+                  id: diff
+                  run: |
+                    git add -A
+                    if git diff --cached --quiet; then
+                      echo "changed=false" >> "$GITHUB_OUTPUT"
+                    else:
+                      echo "changed=true" >> "$GITHUB_OUTPUT"
+                    fi
+
+                - name: Create PR with AI fixes
+                  if: __GHA__ steps.diff.outputs.changed __GHA_END__ == 'true'
+                  uses: peter-evans/create-pull-request@v6
+                  with:
+                    token: __GHA__ secrets.BOT_TOKEN __GHA_END__
+                    branch: ai/airysdark-ai-autofix-__PTYPE__
+                    commit-message: "chore: AirysDark-AI auto-fix (__PTYPE__)"
+                    title: "AirysDark-AI: automated build fix (__PTYPE__)"
+                    body: |
+                      This PR was opened automatically by a generated workflow after a failed build.
+                      - Build command: __GHA__ steps.build.outputs.BUILD_CMD __GHA_END__
+                      - Captured the failing build log
+                      - Proposed a minimal fix via AI
+                      - Committed the changes for review
+                    labels: automation, ci
+          YAML
+
+      - name: Create PR with generated final workflow
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: __GHA__ secrets.BOT_TOKEN __GHA_END__
+          branch: ai/airysdark-ai-workflow-__PTYPE__
+          commit-message: "chore: add AirysDark-AI___PTYPE__ workflow (probed)"
+          title: "AirysDark-AI: add __PTYPE__ workflow (from probe)"
+          body: |
+            This PR adds the final __PTYPE__ AI build workflow, generated by the probe run.
+            - Probed command: __GHA__ steps.probe.outputs.BUILD_CMD __GHA_END__
+            - Next: merge this PR, then run “AirysDark-AI — __PTYPE_CAP__ (generated)”
+          labels: automation, ci
+""".lstrip("\n")
+
+    setup_block = ""
+    if setup_inline.strip():
+        setup_block = textwrap.indent(setup_inline.rstrip() + "\n", " " * 6)
+
+    yaml = (tmpl
+            .replace("__SETUP_INLINE__", setup_block.rstrip("\n"))
+            .replace("__PTYPE__", ptype)
+            .replace("__PTYPE_CAP__", ptype.capitalize())
+            .replace("__GHA__", "${{")
+            .replace("__GHA_END__", "}}"))
+
+    (WF / f"AirysDark-AI_prob_{ptype}.yml").write_text(yaml)
+    print(f"✅ Generated: AirysDark-AI_prob_{ptype}.yml")
+
+# ---------- Main ----------
+def main():
+    types = detect_types()
+    for t in types:
+        write_probe_workflow_for_type(t)
+    print(f"Done. Generated {len(types)} PROBE workflow(s) in {WF}")
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/AirysDark-AI_probe.py
+++ b/tools/AirysDark-AI_probe.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""
+AirysDark-AI_probe.py — deep repo scan to pick the right BUILD_CMD
+Priority:
+  1) Parse README / docs for explicit build commands matching the requested type
+  2) Infer from repo files (heuristics + folder-name bias)
+Prints exactly one line: BUILD_CMD=<command>
+"""
+
+import os, re, shlex, subprocess, sys
+from pathlib import Path
+from typing import List, Tuple, Optional, Dict
+from collections import Counter
+
+ROOT = Path(".").resolve()
+
+TEXT_EXTS = {".md", ".markdown", ".txt", ".rst", ".adoc"}
+DOC_DIR_HINTS = ("docs",)
+MAX_READ_BYTES = 200_000
+MAX_FILES_TO_READ = 400
+
+def scan_all_files() -> List[Tuple[str, Path]]:
+    out = []
+    for root, dirs, files in os.walk(ROOT):
+        if ".git" in dirs:
+            dirs.remove(".git")
+        for f in files:
+            p = Path(root) / f
+            try:
+                rel = p.relative_to(ROOT)
+            except Exception:
+                rel = p
+            out.append((f.lower(), rel))
+    return out
+
+def safe_read_text(p: Path) -> str:
+    try:
+        raw = (ROOT / p).read_bytes()
+        if len(raw) > MAX_READ_BYTES:
+            raw = raw[:MAX_READ_BYTES]
+        return raw.decode("utf-8", errors="ignore")
+    except Exception:
+        return ""
+
+def collect_text_corpus() -> str:
+    files = scan_all_files()
+    picked: List[Path] = []
+
+    for name, rel in files:
+        if Path(rel.name.lower()).name.startswith("readme"):
+            picked.append(rel)
+
+    for name, rel in files:
+        if len(picked) >= MAX_FILES_TO_READ:
+            break
+        if Path(name).suffix in TEXT_EXTS:
+            picked.append(rel)
+
+    for name, rel in files:
+        if len(picked) >= MAX_FILES_TO_READ:
+            break
+        parts = [p.lower() for p in Path(rel).parts]
+        if any(h in parts for h in DOC_DIR_HINTS) and Path(name).suffix in TEXT_EXTS:
+            picked.append(rel)
+
+    seen = set(); ordered: List[Path] = []
+    for p in picked:
+        key = str(p).lower()
+        if key not in seen:
+            seen.add(key); ordered.append(p)
+
+    chunks: List[str] = []
+    for p in ordered[:MAX_FILES_TO_READ]:
+        chunks.append(safe_read_text(p))
+    return "\n\n".join(chunks)
+
+def run(cmd: str, cwd: Optional[Path] = None, capture: bool = True):
+    if capture:
+        p = subprocess.run(cmd, cwd=cwd, shell=True, text=True,
+                           stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        return p.stdout, p.returncode
+    else:
+        p = subprocess.run(cmd, cwd=cwd, shell=True)
+        return "", p.returncode
+
+def prefer_shortest(paths: List[Path]) -> Optional[Path]:
+    if not paths:
+        return None
+    return sorted(paths, key=lambda p: len(Path(str(p)).parts))[0]
+
+def print_output_var(name: str, val: str):
+    print(f"{name}={val}")
+
+# ---------- README/doc extraction ----------
+TYPE_PATTERNS: Dict[str, List[re.Pattern]] = {
+    "android": [re.compile(r"(^|\n|\r)(?:\$?\s*)?(?:\.\/)?gradlew\s+[^\n\r]+", re.I),
+                re.compile(r"(^|\n|\r)(?:\$?\s*)?gradle\s+[^\n\r]+", re.I)],
+    "cmake":   [re.compile(r"(^|\n|\r).*(?:cmake\s+-S\s+\S+|\bcmake\s+\.)\s+-B\s+\S+.*", re.I),
+                re.compile(r"(^|\n|\r).*\bcmake\s+[-\w\/\"\. ]+&&\s*cmake\s+--build[^\n\r]*", re.I)],
+    "linux":   [re.compile(r"(^|\n|\r)(?:\$?\s*)?make(\s+-C\s+\S+)?(\s+-j\S*)?", re.I),
+                re.compile(r"(^|\n|\r).*\bmeson\s+setup[^\n\r]*", re.I),
+                re.compile(r"(^|\n|\r).*\bninja(\s+-C\s+\S+)?[^\n\r]*", re.I)],
+    "node":    [re.compile(r"(^|\n|\r).*\bnpm\s+(?:ci|install)\b[^\n\r]*", re.I),
+                re.compile(r"(^|\n|\r).*\bnpm\s+run\s+build\b[^\n\r]*", re.I),
+                re.compile(r"(^|\n|\r).*\b(pnpm|yarn)\s+(install|build)\b[^\n\r]*", re.I)],
+    "python":  [re.compile(r"(^|\n|\r).*\bpip\s+install\b[^\n\r]*", re.I),
+                re.compile(r"(^|\n|\r).*\bpytest\b[^\n\r]*", re.I),
+                re.compile(r"(^|\n|\r).*\bpython\s+-m\s+pytest\b[^\n\r]*", re.I)],
+    "rust":    [re.compile(r"(^|\n|\r).*\bcargo\s+build\b[^\n\r]*", re.I)],
+    "dotnet":  [re.compile(r"(^|\n|\r).*\bdotnet\s+build\b[^\n\r]*", re.I)],
+    "maven":   [re.compile(r"(^|\n|\r).*\bmvn\b[^\n\r]*", re.I)],
+    "flutter": [re.compile(r"(^|\n|\r).*\bflutter\s+build\b[^\n\r]*", re.I)],
+    "go":      [re.compile(r"(^|\n|\r).*\bgo\s+build\b[^\n\r]*", re.I)],
+    "bazel":   [re.compile(r"(^|\n|\r).*\bbazel(?:isk)?\s+(?:build|test)\b[^\n\r]*", re.I)],
+    "scons":   [re.compile(r"(^|\n|\r).*\bscons\b[^\n\r]*", re.I)],
+    "ninja":   [re.compile(r"(^|\n|\r).*\bninja(\s+-C\s+\S+)?[^\n\r]*", re.I)],
+    "windows": [re.compile(r"(^|\n|\r).*\bmsbuild\b[^\n\r]*", re.I),
+                re.compile(r"(^|\n|\r).*\bdotnet\s+build\b[^\n\r]*", re.I)],
+}
+def extract_doc_command_for_type(ptype: str, corpus: str) -> Optional[str]:
+    pats = TYPE_PATTERNS.get(ptype, [])
+    cands: List[str] = []
+    for pat in pats:
+        for m in pat.finditer(corpus):
+            line = re.sub(r"^[\n\r\s$>]*", "", m.group(0)).strip()
+            if len(line.split()) >= 2:
+                cands.append(line)
+    if not cands:
+        return None
+    cands = sorted(cands, key=lambda s: (len(s), s))
+    return cands[0]
+
+# ---------- folder-name helper ----------
+def any_dir_segment(files: List[Tuple[str, Path]], name: str) -> Optional[Path]:
+    seg = name.lower()
+    for _, rel in files:
+        parts = [p.lower() for p in Path(rel).parts]
+        if seg in parts:
+            # return the path to that segment
+            idx = parts.index(seg)
+            return Path(*Path(rel).parts[: idx + 1])
+    return None
+
+# ---------- probers ----------
+def probe_linux(files: List[Tuple[str, Path]]) -> Optional[str]:
+    makefiles = [p for (n, p) in files if n in ("makefile", "gnumakefile")]
+    mf = prefer_shortest(makefiles)
+    if mf:
+        return "make -j" if str(mf.parent) == "." else f'make -C "{mf.parent}" -j'
+
+    mesons = [p for (n, p) in files if n == "meson.build"]
+    mb = prefer_shortest(mesons)
+    if mb:
+        d = mb.parent
+        return f'(cd "{d}" && (meson setup build --wipe || true); meson setup build || true; ninja -C build)'
+
+    mk_paths = [p for (n, p) in files if str(p).lower().endswith(".mk")]
+    if mk_paths:
+        cnt = Counter(str(p.parent) for p in mk_paths)
+        likely_dir = Path(sorted(cnt.items(), key=lambda kv: (-kv[1], len(Path(kv[0]).parts)))[0][0])
+        return f'make -C "{likely_dir}" -j'
+
+    ldir = any_dir_segment(files, "linux")
+    if ldir:
+        return f'make -C "{ldir}" -j'
+    return None
+
+def is_app_module(dirp: Path) -> bool:
+    for fn in ("build.gradle", "build.gradle.kts"):
+        f = dirp / fn
+        if f.exists():
+            try:
+                if "com.android.application" in f.read_text(errors="ignore"):
+                    return True
+            except Exception:
+                pass
+    return False
+
+def parse_settings_modules(settings_path: Optional[Path]) -> List[str]:
+    if not settings_path or not settings_path.exists():
+        return []
+    try:
+        txt = settings_path.read_text(errors="ignore")
+    except Exception:
+        return []
+    mods = []
+    for raw in re.findall(r'include\s*\((.*?)\)', txt, flags=re.S):
+        for p in re.split(r'[,\s]+', raw.strip()):
+            s = p.strip().strip('"\'')
+
+            if s.startswith(":"):
+                mods.append(s[1:])
+    for raw in re.findall(r'include\s+([^\n]+)', txt):
+        for p in raw.split(","):
+            s = p.strip().strip('"\'')
+
+            if s.startswith(":"):
+                mods.append(s[1:])
+    out, seen = [], set()
+    for m in mods:
+        if m not in seen:
+            seen.add(m)
+            out.append(m)
+    return out
+
+def run_tasks_list(gradlew: Path) -> str:
+    out, _ = run(f"./{gradlew.name} -q tasks --all", cwd=gradlew.parent)
+    return out
+
+def task_exists(tasks_out: str, name: str) -> bool:
+    return re.search(rf"(^|\s){re.escape(name)}(\s|$)", tasks_out) is not None
+
+def probe_android(files: List[Tuple[str, Path]]) -> Optional[str]:
+    gradlews = [p for (n, p) in files if n == "gradlew"]
+    if not gradlews and (ROOT / "gradlew").exists():
+        gradlews = [Path("gradlew")]
+    if not gradlews:
+        return "./gradlew assembleDebug --stacktrace"
+
+    ranked = []
+    for g in gradlews:
+        d = (ROOT / g).parent
+        settings = None
+        for sname in ("settings.gradle", "settings.gradle.kts"):
+            sp = d / sname
+            if sp.exists():
+                settings = sp
+                break
+        modules = parse_settings_modules(settings)
+        has_app = any(is_app_module(d / m.replace(":", "/")) for m in modules)
+        ranked.append((g, settings is not None, has_app))
+    ranked.sort(key=lambda x: (not x[1], not x[2], len(Path(str(x[0])).parts)))
+    g = ranked[0][0]
+    g_abs = (ROOT / g)
+    try:
+        os.chmod(g_abs, 0o755)
+    except Exception:
+        pass
+
+    tasks_out = run_tasks_list(g_abs)
+    base = shlex.quote(str(g_abs.parent))
+    for t in ["assembleDebug", "bundleDebug", "assembleRelease", "bundleRelease", "build"]:
+        if task_exists(tasks_out, t):
+            return f"cd {base} && ./gradlew {t} --stacktrace"
+    for guess in ("app", "mobile", "android"):
+        for t in ["assembleDebug", "bundleDebug", "assembleRelease", "bundleRelease"]:
+            if task_exists(tasks_out, f":{guess}:{t}"):
+                return f"cd {base} && ./gradlew :{guess}:{t} --stacktrace"
+
+    adir = any_dir_segment(files, "android")
+    if adir:
+        return f'cd "{adir}" && ./gradlew assembleDebug --stacktrace'
+    return f"cd {base} && ./gradlew assembleDebug --stacktrace"
+
+def probe_cmake(files: List[Tuple[str, Path]]) -> Optional[str]:
+    cmakes = [p for (n, p) in files if n == "cmakelists.txt"]
+    first = prefer_shortest(cmakes)
+    if not first:
+        return None
+    outdir = f'build/{str(first.parent).replace("/", "_")}'
+    return f'cmake -S "{first.parent}" -B "{outdir}" && cmake --build "{outdir}" -j'
+
+def probe_node(files: List[Tuple[str, Path]]) -> Optional[str]:
+    pkgs = [p for (n, p) in files if n == "package.json"]
+    if not pkgs:
+        return None
+    def has_build_script(pkg_path: Path) -> bool:
+        try:
+            txt = (ROOT / pkg_path).read_text(errors="ignore")
+        except Exception:
+            return False
+        return re.search(r'"scripts"\s*:\s*{[^}]*"build"\s*:', txt, flags=re.S) is not None
+    with_build = [p for p in pkgs if has_build_script(p)]
+    chosen = prefer_shortest(with_build) or prefer_shortest(pkgs)
+    return f'cd "{chosen.parent}" && npm ci && npm run build --if-present'
+
+def probe_python(files: List[Tuple[str, Path]]) -> Optional[str]:
+    pyprojects = [p for (n, p) in files if n == "pyproject.toml"]
+    setups     = [p for (n, p) in files if n == "setup.py"]
+    chosen = prefer_shortest(pyprojects) or prefer_shortest(setups)
+    if not chosen:
+        return None
+    d = chosen.parent
+    return f'cd "{d}" && pip install -e . && (pytest || python -m pytest || true)'
+
+def probe_rust(files: List[Tuple[str, Path]]) -> Optional[str]:
+    cargos = [p for (n, p) in files if n == "cargo.toml"]
+    chosen = prefer_shortest(cargos)
+    if not chosen:
+        return None
+    return f'cd "{chosen.parent}" && cargo build --locked --all-targets --verbose'
+
+def probe_dotnet(files: List[Tuple[str, Path]]) -> Optional[str]:
+    slns = [p for (n, p) in files if str(p).lower().endswith(".sln")]
+    if slns:
+        chosen = prefer_shortest(slns)
+        return f'dotnet restore "{chosen}" && dotnet build "{chosen}" -c Release'
+    csfs = [p for (n, p) in files if str(p).lower().endswith((".csproj", ".fsproj", ".vcxproj"))]
+    chosen = prefer_shortest(csfs)
+    if chosen:
+        return f'dotnet restore "{chosen}" && dotnet build "{chosen}" -c Release'
+    wdir = any_dir_segment(files, "windows")
+    if wdir:
+        return f'cd "{wdir}" && dotnet build -c Release'
+    return None
+
+def probe_maven(files: List[Tuple[str, Path]]) -> Optional[str]:
+    poms = [p for (n, p) in files if n == "pom.xml"]
+    chosen = prefer_shortest(poms)
+    if not chosen:
+        return None
+    return f'mvn -B package --file "{chosen}"'
+
+def probe_flutter(files: List[Tuple[str, Path]]) -> Optional[str]:
+    pubs = [p for (n, p) in files if n == "pubspec.yaml"]
+    chosen = prefer_shortest(pubs)
+    if not chosen:
+        return None
+    return f'cd "{chosen.parent}" && flutter build apk --debug'
+
+def probe_go(files: List[Tuple[str, Path]]) -> Optional[str]:
+    mods = [p for (n, p) in files if n == "go.mod"]
+    chosen = prefer_shortest(mods)
+    if not chosen:
+        return None
+    return f'cd "{chosen.parent}" && go build ./...'
+
+def probe_bazel(files: List[Tuple[str, Path]]) -> Optional[str]:
+    workspaces = [p for (n, p) in files if n in ("workspace", "workspace.bazel", "module.bazel")]
+    builds     = [p for (n, p) in files if n in ("build", "build.bazel")]
+    root = prefer_shortest(workspaces) or prefer_shortest(builds)
+    if not root:
+        return None
+    d = root.parent
+    return f'cd "{d}" && (command -v bazelisk >/dev/null 2>&1 && bazelisk build //... || bazel build //...)'
+
+def probe_scons(files: List[Tuple[str, Path]]) -> Optional[str]:
+    sconstructs = [p for (n, p) in files if n == "sconstruct"]
+    sconss      = [p for (n, p) in files if n == "sconscript"]
+    chosen = prefer_shortest(sconstructs) or prefer_shortest(sconss)
+    if not chosen:
+        return None
+    d = chosen.parent
+    return f'scons -C "{d}" -j'
+
+def probe_ninja(files: List[Tuple[str, Path]]) -> Optional[str]:
+    ninjas = [p for (n, p) in files if n == "build.ninja"]
+    chosen = prefer_shortest(ninjas)
+    if not chosen:
+        return None
+    return f'ninja -C "{chosen.parent}"'
+
+def main():
+    if len(sys.argv) < 3 or sys.argv[1] != "--type":
+        print("Usage: AirysDark-AI_probe.py --type <android|cmake|linux|node|python|rust|dotnet|maven|flutter|go|bazel|scons|ninja|windows|unknown>")
+        return 2
+    ptype = sys.argv[2].strip().lower()
+
+    # 1) README/doc parsing
+    corpus = collect_text_corpus()
+    doc_cmd = extract_doc_command_for_type(ptype, corpus)
+    if doc_cmd:
+        print_output_var("BUILD_CMD", doc_cmd)
+        return 0
+
+    # 2) file-based probing
+    files = scan_all_files()
+    dispatch = {
+        "android": probe_android,
+        "cmake":   probe_cmake,
+        "linux":   probe_linux,
+        "node":    probe_node,
+        "python":  probe_python,
+        "rust":    probe_rust,
+        "dotnet":  probe_dotnet,
+        "maven":   probe_maven,
+        "flutter": probe_flutter,
+        "go":      probe_go,
+        "bazel":   probe_bazel,
+        "scons":   probe_scons,
+        "ninja":   probe_ninja,
+        "windows": probe_dotnet,   # reuse .NET probing for windows
+        "unknown": lambda _f: "echo 'No build system detected' && exit 1",
+    }
+    func = dispatch.get(ptype, dispatch["unknown"])
+    cmd = func(files)
+
+    if not cmd:
+        friendly = {
+            "linux":   "echo 'No Makefile / meson.build found (only .mk includes?)' && exit 1",
+            "cmake":   "echo 'No CMakeLists.txt found' && exit 1",
+            "bazel":   "echo 'No Bazel WORKSPACE / BUILD found' && exit 1",
+            "scons":   "echo 'No SConstruct / SConscript found' && exit 1",
+            "ninja":   "echo 'No build.ninja found' && exit 1",
+            "windows": "echo 'No .sln/.csproj/.vcxproj found (Windows)' && exit 1",
+        }
+        cmd = friendly.get(ptype, "echo 'No build system detected' && exit 1")
+
+    print_output_var("BUILD_CMD", cmd)
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This PR adds one **PROBE** workflow per detected build type.

How to proceed:
1) Merge this PR.
2) Run the desired "AirysDark-AI — Probe <Type>" workflow from Actions.
   - It will scan the entire repo, pick the correct BUILD_CMD.
   - It will then generate the final AI build workflow `.github/workflows/AirysDark-AI_<type>.yml`
     and open a second PR with that workflow.
3) Merge the second PR to enable the final build+AI workflow for that type.

Notes:
- These probe workflows use the canonical tools:
  https://github.com/AirysDark-AI/AirysDark-AI_builder/tree/main/tools
- Ensure you set `BOT_TOKEN` (a PAT with `repo` + `workflow` scopes) in repo Secrets.