### PR TITLE
AirysDark-AI: add per-type PROBE workflows

### DIFF
--- a/.github/workflows/AirysDark-AI_prob_android.yml
+++ b/.github/workflows/AirysDark-AI_prob_android.yml
@@ -1,0 +1,236 @@
+name: AirysDark-AI - Probe Android
+
+'on':
+  workflow_dispatch: {}
+  push:
+    branches:
+      - '**'
+  pull_request: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install requests
+
+      - name: Ensure AirysDark-AI tools (detector, probe, builder)
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p tools
+          BASE_URL="https://raw.githubusercontent.com/AirysDark-AI/AirysDark-AI_builder/main/tools"
+          curl -fL "$BASE_URL/AirysDark-AI_detector.py" -o tools/AirysDark-AI_detector.py
+          curl -fL "$BASE_URL/AirysDark-AI_probe.py"     -o tools/AirysDark-AI_probe.py
+          curl -fL "$BASE_URL/AirysDark-AI_builder.py"  -o tools/AirysDark-AI_builder.py
+          ls -la tools
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+      - uses: android-actions/setup-android@v3
+      - run: yes | sdkmanager --licenses
+      - run: sdkmanager "platform-tools" "platforms;android-34" "build-tools;34.0.0"
+      - name: Probe build command (Android)
+        id: probe
+        shell: bash
+        run: |
+          set -euxo pipefail
+          python3 tools/AirysDark-AI_probe.py --type "android" | tee /tmp/probe.out
+          CMD=$(grep -E '^BUILD_CMD=' /tmp/probe.out | sed 's/^BUILD_CMD=//')
+          echo "BUILD_CMD=$CMD" >> "$GITHUB_OUTPUT"
+
+      - name: Generate final workflow .github/workflows/AirysDark-AI_android.yml
+        shell: bash
+        env:
+          BUILD_CMD: "${{ steps.probe.outputs.BUILD_CMD }}"
+        run: |
+          set -euo pipefail
+          mkdir -p .github/workflows
+          cat > .github/workflows/AirysDark-AI_android.yml <<'YAML'
+          name: AirysDark-AI - Android (generated)
+
+          'on':
+            workflow_dispatch: {}
+            push:
+              branches:
+                - '**'
+            pull_request: {}
+
+          jobs:
+            build:
+              runs-on: ubuntu-latest
+              permissions:
+                contents: write
+                pull-requests: write
+              steps:
+                - uses: actions/checkout@v4
+                  with:
+                    fetch-depth: 0
+                    persist-credentials: false
+
+                - uses: actions/setup-python@v5
+                  with:
+                    python-version: "3.11"
+                - run: pip install requests
+
+                # Android SDK / Java
+                - uses: actions/setup-java@v4
+                  with:
+                    distribution: temurin
+                    java-version: "17"
+                - uses: android-actions/setup-android@v3
+                - run: yes | sdkmanager --licenses
+                - run: sdkmanager "platform-tools" "platforms;android-34" "build-tools;34.0.0"
+
+                - name: Ensure AirysDark-AI tools (detector, builder)
+                  shell: bash
+                  run: |
+                    set -euo pipefail
+                    mkdir -p tools
+                    BASE_URL="https://raw.githubusercontent.com/AirysDark-AI/AirysDark-AI_builder/main/tools"
+                    [ -f tools/AirysDark-AI_detector.py ] || curl -fL "$BASE_URL/AirysDark-AI_detector.py" -o tools/AirysDark-AI_detector.py
+                    [ -f tools/AirysDark-AI_builder.py ]  || curl -fL "$BASE_URL/AirysDark-AI_builder.py"  -o tools/AirysDark-AI_builder.py
+
+                - name: Build (capture)
+                  id: build
+                  shell: bash
+                  run: |
+                    set -euxo pipefail
+                    CMD="$BUILD_CMD"
+                    echo "BUILD_CMD=$CMD" >> "$GITHUB_OUTPUT"
+                    set +e; bash -lc "$CMD" | tee build.log; EXIT=$?; set -e
+                    echo "EXIT_CODE=$EXIT" >> "$GITHUB_OUTPUT"
+                    [ -s build.log ] || echo "(no build output captured)" > build.log
+                    exit 0
+                  continue-on-error: true
+
+                - name: Upload build log
+                  if: always()
+                  uses: actions/upload-artifact@v4
+                  with:
+                    name: android-build-log
+                    path: build.log
+                    if-no-files-found: warn
+                    retention-days: 7
+
+                # --- AI auto-fix (OpenAI -> llama.cpp) ---
+                - name: Build llama.cpp (CMake, no CURL, in temp)
+                  if: always() && ${{ steps.build.outputs.EXIT_CODE != '0' }}
+                  run: |
+                    set -euxo pipefail
+                    TMP="${{ runner.temp }}"
+                    cd "$TMP"
+                    rm -rf llama.cpp
+                    git clone --depth=1 https://github.com/ggml-org/llama.cpp
+                    cd llama.cpp
+                    cmake -S . -B build -D CMAKE_BUILD_TYPE=Release -DLLAMA_CURL=OFF
+                    cmake --build build -j
+                    echo "LLAMA_CPP_BIN=$PWD/build/bin/llama-cli" >> $GITHUB_ENV
+
+                - name: Fetch GGUF model (TinyLlama)
+                  if: always() && ${{ steps.build.outputs.EXIT_CODE != '0' }}
+                  run: |
+                    mkdir -p models
+                    curl -L -o models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf \
+                      https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf
+
+                - name: Attempt AI auto-fix (OpenAI -> llama fallback)
+                  if: always() && ${{ steps.build.outputs.EXIT_CODE != '0' }}
+                  env:
+                    PROVIDER: openai
+                    FALLBACK_PROVIDER: llama
+                    OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+                    OPENAI_MODEL: ${{ vars.OPENAI_MODEL || 'gpt-4o-mini' }}
+                    MODEL_PATH: models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf
+                    AI_BUILDER_ATTEMPTS: "3"
+                    BUILD_CMD: ${{ steps.build.outputs.BUILD_CMD }}
+                  run: python3 tools/AirysDark-AI_builder.py || true
+
+                - name: Upload AI patch (if any)
+                  if: always()
+                  uses: actions/upload-artifact@v4
+                  with:
+                    name: android-ai-patch
+                    path: .pre_ai_fix.patch
+                    if-no-files-found: ignore
+                    retention-days: 7
+
+                - name: Check for changes
+                  id: diff
+                  run: |
+                    git add -A
+                    if git diff --cached --quiet; then
+                      echo "changed=false" >> "$GITHUB_OUTPUT"
+                    else:
+                      echo "changed=true" >> "$GITHUB_OUTPUT"
+                    fi
+
+                - name: Pin git remote with token (just-in-time)
+                  if: ${{ steps.diff.outputs.changed == 'true' }}
+                  env:
+                    BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+                    REPO_SLUG: ${{ github.repository }}
+                  run: |
+                    set -euxo pipefail
+                    git config --local --name-only --get-regexp '^http\.https://github\.com/\.extraheader$' >/dev/null 2>&1 && \
+                      git config --local --unset-all http.https://github.com/.extraheader || true
+                    git config --global --add safe.directory "$GITHUB_WORKSPACE"
+                    git remote set-url origin "https://x-access-token:${BOT_TOKEN}@github.com/${REPO_SLUG}.git"
+                    git config --global url."https://x-access-token:${BOT_TOKEN}@github.com/".insteadOf "https://github.com/"
+                    git remote -v
+
+                - name: Create PR with AI fixes
+                  if: ${{ steps.diff.outputs.changed == 'true' }}
+                  uses: peter-evans/create-pull-request@v6
+                  with:
+                    token: ${{ secrets.BOT_TOKEN }}
+                    branch: ai/airysdark-ai-autofix-android
+                    commit-message: "chore: AirysDark-AI auto-fix (android)"
+                    title: "AirysDark-AI: automated build fix (android)"
+                    body: |
+                      This PR was opened automatically by a generated workflow after a failed build.
+                      - Build command: ${{ steps.build.outputs.BUILD_CMD }}
+                      - Captured the failing build log
+                      - Proposed a minimal fix via AI
+                      - Committed the changes for review
+                    labels: automation, ci
+          YAML
+
+      - name: Pin git remote with token (just-in-time)
+        env:
+          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+          REPO_SLUG: ${{ github.repository }}
+        run: |
+          set -euxo pipefail
+          git config --local --name-only --get-regexp '^http\.https://github\.com/\.extraheader$' >/dev/null 2>&1 && \
+            git config --local --unset-all http.https://github.com/.extraheader || true
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git remote set-url origin "https://x-access-token:${BOT_TOKEN}@github.com/${REPO_SLUG}.git"
+          git config --global url."https://x-access-token:${BOT_TOKEN}@github.com/".insteadOf "https://github.com/"
+          git remote -v
+
+      - name: Create PR with generated final workflow
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.BOT_TOKEN }}
+          branch: ai/airysdark-ai-workflow-android
+          commit-message: "chore: add AirysDark-AI_android workflow (probed)"
+          title: "AirysDark-AI: add Android workflow (from probe)"
+          body: |
+            This PR adds the final Android AI build workflow, generated by the probe run.
+            - Probed command: ${{ steps.probe.outputs.BUILD_CMD }}
+            - Next: merge this PR, then run "AirysDark-AI - Android (generated)"
+          labels: automation, ci

--- a/.github/workflows/AirysDark-AI_prob_cmake.yml
+++ b/.github/workflows/AirysDark-AI_prob_cmake.yml
@@ -1,0 +1,222 @@
+name: AirysDark-AI - Probe Cmake
+
+'on':
+  workflow_dispatch: {}
+  push:
+    branches:
+      - '**'
+  pull_request: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install requests
+
+      - name: Ensure AirysDark-AI tools (detector, probe, builder)
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p tools
+          BASE_URL="https://raw.githubusercontent.com/AirysDark-AI/AirysDark-AI_builder/main/tools"
+          curl -fL "$BASE_URL/AirysDark-AI_detector.py" -o tools/AirysDark-AI_detector.py
+          curl -fL "$BASE_URL/AirysDark-AI_probe.py"     -o tools/AirysDark-AI_probe.py
+          curl -fL "$BASE_URL/AirysDark-AI_builder.py"  -o tools/AirysDark-AI_builder.py
+          ls -la tools
+
+      - name: Probe build command
+        id: probe
+        shell: bash
+        run: |
+          set -euxo pipefail
+          python3 tools/AirysDark-AI_probe.py --type "cmake" | tee /tmp/probe.out
+          CMD=$(grep -E '^BUILD_CMD=' /tmp/probe.out | sed 's/^BUILD_CMD=//')
+          echo "BUILD_CMD=$CMD" >> "$GITHUB_OUTPUT"
+
+      - name: Generate final workflow .github/workflows/AirysDark-AI_cmake.yml
+        shell: bash
+        env:
+          BUILD_CMD: "${{ steps.probe.outputs.BUILD_CMD }}"
+        run: |
+          set -euo pipefail
+          mkdir -p .github/workflows
+          cat > .github/workflows/AirysDark-AI_cmake.yml <<'YAML'
+          name: AirysDark-AI - Cmake (generated)
+
+          'on':
+            workflow_dispatch: {}
+            push:
+              branches:
+                - '**'
+            pull_request: {}
+
+          jobs:
+            build:
+              runs-on: ubuntu-latest
+              permissions:
+                contents: write
+                pull-requests: write
+              steps:
+                - uses: actions/checkout@v4
+                  with:
+                    fetch-depth: 0
+                    persist-credentials: false
+
+                - uses: actions/setup-python@v5
+                  with:
+                    python-version: "3.11"
+                - run: pip install requests
+
+                - name: Ensure AirysDark-AI tools (detector, builder)
+                  shell: bash
+                  run: |
+                    set -euo pipefail
+                    mkdir -p tools
+                    BASE_URL="https://raw.githubusercontent.com/AirysDark-AI/AirysDark-AI_builder/main/tools"
+                    [ -f tools/AirysDark-AI_detector.py ] || curl -fL "$BASE_URL/AirysDark-AI_detector.py" -o tools/AirysDark-AI_detector.py
+                    [ -f tools/AirysDark-AI_builder.py ]  || curl -fL "$BASE_URL/AirysDark-AI_builder.py"  -o tools/AirysDark-AI_builder.py
+
+                - name: Build (capture)
+                  id: build
+                  shell: bash
+                  run: |
+                    set -euxo pipefail
+                    CMD="$BUILD_CMD"
+                    echo "BUILD_CMD=$CMD" >> "$GITHUB_OUTPUT"
+                    set +e; bash -lc "$CMD" | tee build.log; EXIT=$?; set -e
+                    echo "EXIT_CODE=$EXIT" >> "$GITHUB_OUTPUT"
+                    [ -s build.log ] || echo "(no build output captured)" > build.log
+                    exit 0
+                  continue-on-error: true
+
+                - name: Upload build log
+                  if: always()
+                  uses: actions/upload-artifact@v4
+                  with:
+                    name: cmake-build-log
+                    path: build.log
+                    if-no-files-found: warn
+                    retention-days: 7
+
+                # --- AI auto-fix (OpenAI -> llama.cpp) ---
+                - name: Build llama.cpp (CMake, no CURL, in temp)
+                  if: always() && ${{ steps.build.outputs.EXIT_CODE != '0' }}
+                  run: |
+                    set -euxo pipefail
+                    TMP="${{ runner.temp }}"
+                    cd "$TMP"
+                    rm -rf llama.cpp
+                    git clone --depth=1 https://github.com/ggml-org/llama.cpp
+                    cd llama.cpp
+                    cmake -S . -B build -D CMAKE_BUILD_TYPE=Release -DLLAMA_CURL=OFF
+                    cmake --build build -j
+                    echo "LLAMA_CPP_BIN=$PWD/build/bin/llama-cli" >> $GITHUB_ENV
+
+                - name: Fetch GGUF model (TinyLlama)
+                  if: always() && ${{ steps.build.outputs.EXIT_CODE != '0' }}
+                  run: |
+                    mkdir -p models
+                    curl -L -o models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf \
+                      https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf
+
+                - name: Attempt AI auto-fix (OpenAI -> llama fallback)
+                  if: always() && ${{ steps.build.outputs.EXIT_CODE != '0' }}
+                  env:
+                    PROVIDER: openai
+                    FALLBACK_PROVIDER: llama
+                    OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+                    OPENAI_MODEL: ${{ vars.OPENAI_MODEL || 'gpt-4o-mini' }}
+                    MODEL_PATH: models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf
+                    AI_BUILDER_ATTEMPTS: "3"
+                    BUILD_CMD: ${{ steps.build.outputs.BUILD_CMD }}
+                  run: python3 tools/AirysDark-AI_builder.py || true
+
+                - name: Upload AI patch (if any)
+                  if: always()
+                  uses: actions/upload-artifact@v4
+                  with:
+                    name: cmake-ai-patch
+                    path: .pre_ai_fix.patch
+                    if-no-files-found: ignore
+                    retention-days: 7
+
+                - name: Check for changes
+                  id: diff
+                  run: |
+                    git add -A
+                    if git diff --cached --quiet; then
+                      echo "changed=false" >> "$GITHUB_OUTPUT"
+                    else:
+                      echo "changed=true" >> "$GITHUB_OUTPUT"
+                    fi
+
+                # Pin remote with BOT_TOKEN before creating PR (avoids credential issues)
+                - name: Pin git remote with token (just-in-time)
+                  if: ${{ steps.diff.outputs.changed == 'true' }}
+                  env:
+                    BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+                    REPO_SLUG: ${{ github.repository }}
+                  run: |
+                    set -euxo pipefail
+                    git config --local --name-only --get-regexp '^http\.https://github\.com/\.extraheader$' >/dev/null 2>&1 && \
+                      git config --local --unset-all http.https://github.com/.extraheader || true
+                    git config --global --add safe.directory "$GITHUB_WORKSPACE"
+                    git remote set-url origin "https://x-access-token:${BOT_TOKEN}@github.com/${REPO_SLUG}.git"
+                    git config --global url."https://x-access-token:${BOT_TOKEN}@github.com/".insteadOf "https://github.com/"
+                    git remote -v
+
+                - name: Create PR with AI fixes
+                  if: ${{ steps.diff.outputs.changed == 'true' }}
+                  uses: peter-evans/create-pull-request@v6
+                  with:
+                    token: ${{ secrets.BOT_TOKEN }}
+                    branch: ai/airysdark-ai-autofix-cmake
+                    commit-message: "chore: AirysDark-AI auto-fix (cmake)"
+                    title: "AirysDark-AI: automated build fix (cmake)"
+                    body: |
+                      This PR was opened automatically by a generated workflow after a failed build.
+                      - Build command: ${{ steps.build.outputs.BUILD_CMD }}
+                      - Captured the failing build log
+                      - Proposed a minimal fix via AI
+                      - Committed the changes for review
+                    labels: automation, ci
+          YAML
+
+      # Pin before PR that adds the final workflow
+      - name: Pin git remote with token (just-in-time)
+        env:
+          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+          REPO_SLUG: ${{ github.repository }}
+        run: |
+          set -euxo pipefail
+          git config --local --name-only --get-regexp '^http\.https://github\.com/\.extraheader$' >/dev/null 2>&1 && \
+            git config --local --unset-all http.https://github.com/.extraheader || true
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git remote set-url origin "https://x-access-token:${BOT_TOKEN}@github.com/${REPO_SLUG}.git"
+          git config --global url."https://x-access-token:${BOT_TOKEN}@github.com/".insteadOf "https://github.com/"
+          git remote -v
+
+      - name: Create PR with generated final workflow
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.BOT_TOKEN }}
+          branch: ai/airysdark-ai-workflow-cmake
+          commit-message: "chore: add AirysDark-AI_cmake workflow (probed)"
+          title: "AirysDark-AI: add cmake workflow (from probe)"
+          body: |
+            This PR adds the final cmake AI build workflow, generated by the probe run.
+            - Probed command: ${{ steps.probe.outputs.BUILD_CMD }}
+            - Next: merge this PR, then run \"AirysDark-AI - Cmake (generated)\"
+          labels: automation, ci

--- a/.github/workflows/AirysDark-AI_prob_linux.yml
+++ b/.github/workflows/AirysDark-AI_prob_linux.yml
@@ -1,0 +1,230 @@
+name: AirysDark-AI - Probe Linux
+
+'on':
+  workflow_dispatch: {}
+  push:
+    branches:
+      - '**'
+  pull_request: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install requests
+
+      - name: Ensure AirysDark-AI tools (detector, probe, builder)
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p tools
+          BASE_URL="https://raw.githubusercontent.com/AirysDark-AI/AirysDark-AI_builder/main/tools"
+          curl -fL "$BASE_URL/AirysDark-AI_detector.py" -o tools/AirysDark-AI_detector.py
+          curl -fL "$BASE_URL/AirysDark-AI_probe.py"     -o tools/AirysDark-AI_probe.py
+          curl -fL "$BASE_URL/AirysDark-AI_builder.py"  -o tools/AirysDark-AI_builder.py
+          ls -la tools
+
+      - name: Install Meson & Ninja (Linux only)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y meson ninja-build pkg-config
+      - name: Probe build command
+        id: probe
+        shell: bash
+        run: |
+          set -euxo pipefail
+          python3 tools/AirysDark-AI_probe.py --type "linux" | tee /tmp/probe.out
+          CMD=$(grep -E '^BUILD_CMD=' /tmp/probe.out | sed 's/^BUILD_CMD=//')
+          echo "BUILD_CMD=$CMD" >> "$GITHUB_OUTPUT"
+
+      - name: Generate final workflow .github/workflows/AirysDark-AI_linux.yml
+        shell: bash
+        env:
+          BUILD_CMD: "${{ steps.probe.outputs.BUILD_CMD }}"
+        run: |
+          set -euo pipefail
+          mkdir -p .github/workflows
+          cat > .github/workflows/AirysDark-AI_linux.yml <<'YAML'
+          name: AirysDark-AI - Linux (generated)
+
+          'on':
+            workflow_dispatch: {}
+            push:
+              branches:
+                - '**'
+            pull_request: {}
+
+          jobs:
+            build:
+              runs-on: ubuntu-latest
+              permissions:
+                contents: write
+                pull-requests: write
+              steps:
+                - uses: actions/checkout@v4
+                  with:
+                    fetch-depth: 0
+                    persist-credentials: false
+
+                - uses: actions/setup-python@v5
+                  with:
+                    python-version: "3.11"
+                - run: pip install requests
+
+      - name: Install Meson & Ninja (Linux only)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y meson ninja-build pkg-config
+                - name: Ensure AirysDark-AI tools (detector, builder)
+                  shell: bash
+                  run: |
+                    set -euo pipefail
+                    mkdir -p tools
+                    BASE_URL="https://raw.githubusercontent.com/AirysDark-AI/AirysDark-AI_builder/main/tools"
+                    [ -f tools/AirysDark-AI_detector.py ] || curl -fL "$BASE_URL/AirysDark-AI_detector.py" -o tools/AirysDark-AI_detector.py
+                    [ -f tools/AirysDark-AI_builder.py ]  || curl -fL "$BASE_URL/AirysDark-AI_builder.py"  -o tools/AirysDark-AI_builder.py
+
+                - name: Build (capture)
+                  id: build
+                  shell: bash
+                  run: |
+                    set -euxo pipefail
+                    CMD="$BUILD_CMD"
+                    echo "BUILD_CMD=$CMD" >> "$GITHUB_OUTPUT"
+                    set +e; bash -lc "$CMD" | tee build.log; EXIT=$?; set -e
+                    echo "EXIT_CODE=$EXIT" >> "$GITHUB_OUTPUT"
+                    [ -s build.log ] || echo "(no build output captured)" > build.log
+                    exit 0
+                  continue-on-error: true
+
+                - name: Upload build log
+                  if: always()
+                  uses: actions/upload-artifact@v4
+                  with:
+                    name: linux-build-log
+                    path: build.log
+                    if-no-files-found: warn
+                    retention-days: 7
+
+                # --- AI auto-fix (OpenAI -> llama.cpp) ---
+                - name: Build llama.cpp (CMake, no CURL, in temp)
+                  if: always() && ${{ steps.build.outputs.EXIT_CODE != '0' }}
+                  run: |
+                    set -euxo pipefail
+                    TMP="${{ runner.temp }}"
+                    cd "$TMP"
+                    rm -rf llama.cpp
+                    git clone --depth=1 https://github.com/ggml-org/llama.cpp
+                    cd llama.cpp
+                    cmake -S . -B build -D CMAKE_BUILD_TYPE=Release -DLLAMA_CURL=OFF
+                    cmake --build build -j
+                    echo "LLAMA_CPP_BIN=$PWD/build/bin/llama-cli" >> $GITHUB_ENV
+
+                - name: Fetch GGUF model (TinyLlama)
+                  if: always() && ${{ steps.build.outputs.EXIT_CODE != '0' }}
+                  run: |
+                    mkdir -p models
+                    curl -L -o models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf \
+                      https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf
+
+                - name: Attempt AI auto-fix (OpenAI -> llama fallback)
+                  if: always() && ${{ steps.build.outputs.EXIT_CODE != '0' }}
+                  env:
+                    PROVIDER: openai
+                    FALLBACK_PROVIDER: llama
+                    OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+                    OPENAI_MODEL: ${{ vars.OPENAI_MODEL || 'gpt-4o-mini' }}
+                    MODEL_PATH: models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf
+                    AI_BUILDER_ATTEMPTS: "3"
+                    BUILD_CMD: ${{ steps.build.outputs.BUILD_CMD }}
+                  run: python3 tools/AirysDark-AI_builder.py || true
+
+                - name: Upload AI patch (if any)
+                  if: always()
+                  uses: actions/upload-artifact@v4
+                  with:
+                    name: linux-ai-patch
+                    path: .pre_ai_fix.patch
+                    if-no-files-found: ignore
+                    retention-days: 7
+
+                - name: Check for changes
+                  id: diff
+                  run: |
+                    git add -A
+                    if git diff --cached --quiet; then
+                      echo "changed=false" >> "$GITHUB_OUTPUT"
+                    else:
+                      echo "changed=true" >> "$GITHUB_OUTPUT"
+                    fi
+
+                # Pin remote with BOT_TOKEN before creating PR (avoids credential issues)
+                - name: Pin git remote with token (just-in-time)
+                  if: ${{ steps.diff.outputs.changed == 'true' }}
+                  env:
+                    BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+                    REPO_SLUG: ${{ github.repository }}
+                  run: |
+                    set -euxo pipefail
+                    git config --local --name-only --get-regexp '^http\.https://github\.com/\.extraheader$' >/dev/null 2>&1 && \
+                      git config --local --unset-all http.https://github.com/.extraheader || true
+                    git config --global --add safe.directory "$GITHUB_WORKSPACE"
+                    git remote set-url origin "https://x-access-token:${BOT_TOKEN}@github.com/${REPO_SLUG}.git"
+                    git config --global url."https://x-access-token:${BOT_TOKEN}@github.com/".insteadOf "https://github.com/"
+                    git remote -v
+
+                - name: Create PR with AI fixes
+                  if: ${{ steps.diff.outputs.changed == 'true' }}
+                  uses: peter-evans/create-pull-request@v6
+                  with:
+                    token: ${{ secrets.BOT_TOKEN }}
+                    branch: ai/airysdark-ai-autofix-linux
+                    commit-message: "chore: AirysDark-AI auto-fix (linux)"
+                    title: "AirysDark-AI: automated build fix (linux)"
+                    body: |
+                      This PR was opened automatically by a generated workflow after a failed build.
+                      - Build command: ${{ steps.build.outputs.BUILD_CMD }}
+                      - Captured the failing build log
+                      - Proposed a minimal fix via AI
+                      - Committed the changes for review
+                    labels: automation, ci
+          YAML
+
+      # Pin before PR that adds the final workflow
+      - name: Pin git remote with token (just-in-time)
+        env:
+          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+          REPO_SLUG: ${{ github.repository }}
+        run: |
+          set -euxo pipefail
+          git config --local --name-only --get-regexp '^http\.https://github\.com/\.extraheader$' >/dev/null 2>&1 && \
+            git config --local --unset-all http.https://github.com/.extraheader || true
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git remote set-url origin "https://x-access-token:${BOT_TOKEN}@github.com/${REPO_SLUG}.git"
+          git config --global url."https://x-access-token:${BOT_TOKEN}@github.com/".insteadOf "https://github.com/"
+          git remote -v
+
+      - name: Create PR with generated final workflow
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.BOT_TOKEN }}
+          branch: ai/airysdark-ai-workflow-linux
+          commit-message: "chore: add AirysDark-AI_linux workflow (probed)"
+          title: "AirysDark-AI: add linux workflow (from probe)"
+          body: |
+            This PR adds the final linux AI build workflow, generated by the probe run.
+            - Probed command: ${{ steps.probe.outputs.BUILD_CMD }}
+            - Next: merge this PR, then run \"AirysDark-AI - Linux (generated)\"
+          labels: automation, ci

--- a/tools/AirysDark-AI_builder.py
+++ b/tools/AirysDark-AI_builder.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+# AirysDark-AI_builder.py (OpenAI -> llama.cpp fallback)
+#
+# Env:
+#   PROVIDER=openai|llama      (default openai)
+#   OPENAI_API_KEY=...         (needed if PROVIDER=openai)
+#   OPENAI_MODEL=gpt-4o-mini   (override with repo/Actions vars)
+#   FALLBACK_PROVIDER=llama
+#   MODEL_PATH=models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf
+#   LLAMA_CPP_BIN=llama-cli
+#   LLAMA_CTX=4096
+#   MAX_PROMPT_TOKENS=2500     (~4 chars/token crude)
+#   AI_LOG_TAIL=120
+#   MAX_FILES_IN_TREE=120
+#   RECENT_DIFF_MAX_CHARS=6000
+#   AI_BUILDER_ATTEMPTS=3
+#   BUILD_CMD=...              (must be supplied by the workflow)
+#   PROJECT_ROOT="."
+#
+# Output:
+#   - build.log (captured)
+#   - .pre_ai_fix.patch (staged diff before AI patch)
+#   - commits changes with message "airysdark-ai: apply automatic fix"
+
+import os, sys, subprocess, json, tempfile, re, pathlib, requests
+
+# -------- Config (env-overridable) --------
+PROVIDER = os.getenv("PROVIDER", "openai")
+OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+
+FALLBACK_PROVIDER = os.getenv("FALLBACK_PROVIDER", "llama")
+LLAMA_CPP_BIN = os.getenv("LLAMA_CPP_BIN", "llama-cli")
+LLAMA_MODEL_PATH = os.getenv("MODEL_PATH", "models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf")
+
+LLAMA_CTX = int(os.getenv("LLAMA_CTX", "4096"))
+MAX_PROMPT_TOKENS = int(os.getenv("MAX_PROMPT_TOKENS", "2500"))
+AI_LOG_TAIL = int(os.getenv("AI_LOG_TAIL", "120"))
+MAX_FILES_IN_TREE = int(os.getenv("MAX_FILES_IN_TREE", "120"))
+RECENT_DIFF_MAX_CHARS = int(os.getenv("RECENT_DIFF_MAX_CHARS", "6000"))
+
+MAX_ATTEMPTS = int(os.getenv("AI_BUILDER_ATTEMPTS", "3"))
+BUILD_CMD = os.getenv("BUILD_CMD", "echo 'No BUILD_CMD set' && exit 1")
+PROJECT_ROOT = pathlib.Path(os.getenv("PROJECT_ROOT", ".")).resolve()
+
+PROMPT = """You are an automated build fixer operating on a Git repository.
+
+GOAL: Fix build/test failures with the smallest, safest changes.
+
+Repository file list (truncated):
+{repo_tree}
+
+Recent changes (last few commits diff, truncated):
+{recent_diff}
+
+Build command:
+{build_cmd}
+
+Build log tail (last {ai_log_tail} lines):
+{build_tail}
+
+Constraints:
+- Return ONLY a valid unified diff starting with ---/+++ and @@ hunks.
+- Keep edits minimal, precise, and safe.
+- If build config changes are needed (Gradle/CMake/Workflow/etc.), include them in the diff.
+- Prefer updating APIs or versions only if that’s the root cause.
+- Do NOT modify unrelated files.
+
+Now output ONLY the unified diff to fix the error.
+"""
+
+# -------- helpers --------
+def run(cmd, cwd=PROJECT_ROOT, capture=False, check=False):
+    if capture:
+        return subprocess.run(cmd, cwd=cwd, shell=True, text=True,
+                              stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=check)
+    else:
+        return subprocess.run(cmd, cwd=cwd, shell=True, check=check)
+
+def git(*args, capture=False):
+    return run("git " + " ".join(args), capture=capture)
+
+def get_repo_tree(max_files=MAX_FILES_IN_TREE):
+    out = run("git ls-files || true", capture=True)
+    files = out.stdout.strip().splitlines()
+    return "\n".join(files[:max_files])
+
+def get_recent_diff(max_chars=RECENT_DIFF_MAX_CHARS):
+    tip = run("git log --oneline -n 1 || true", capture=True).stdout.strip()
+    if not tip:
+        return "(no recent commits)"
+    diff = run("git diff --unified=2 -M -C HEAD~5..HEAD || true", capture=True).stdout
+    if not diff:
+        return "(no changes in last 5 commits)"
+    return diff[-max_chars:]
+
+def tail_build_log(lines=None):
+    if lines is None:
+        lines = AI_LOG_TAIL
+    p = pathlib.Path("build.log")
+    if not p.exists():
+        return "(no build log)"
+    data = p.read_text(errors="ignore").splitlines()
+    return "\n".join(data[-int(lines):])
+
+def truncate_prompt(p: str, max_tokens=MAX_PROMPT_TOKENS):
+    char_limit = max_tokens * 4
+    if len(p) <= char_limit:
+        return p
+    head = p[: int(char_limit * 0.60)]
+    tail = p[- int(char_limit * 0.35):]
+    return head + "\n\n[...prompt truncated to fit context...]\n\n" + tail
+
+def run_build():
+    with open("build.log", "wb") as f:
+        p = subprocess.Popen(BUILD_CMD, cwd=PROJECT_ROOT, shell=True,
+                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        for line in p.stdout:
+            sys.stdout.buffer.write(line)
+            f.write(line)
+    return p.wait()
+
+# -------- LLM calls --------
+def _call_openai(prompt):
+    key = os.environ.get("OPENAI_API_KEY")
+    if not key:
+        raise RuntimeError("openai_error: missing OPENAI_API_KEY")
+
+    url = "https://api.openai.com/v1/chat/completions"
+    payload = {
+        "model": OPENAI_MODEL,
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": 0.2,
+    }
+    headers = {
+        "Authorization": f"Bearer {key}",
+        "Content-Type": "application/json",
+    }
+    if os.getenv("OPENAI_ORG"):
+        headers["OpenAI-Organization"] = os.environ["OPENAI_ORG"]
+
+    r = requests.post(url, headers=headers, json=payload, timeout=180)
+    if r.status_code >= 400:
+        try:
+            err = r.json()
+        except Exception:
+            err = {"raw": r.text}
+        print("OpenAI API error:", json.dumps(err, indent=2))
+        raise RuntimeError(f"openai_error:{json.dumps(err)}")
+    data = r.json()
+    return data["choices"][0]["message"]["content"]
+
+def _call_llama(prompt):
+    mp = pathlib.Path(LLAMA_MODEL_PATH)
+    if not mp.exists():
+        print(f"llama.cpp: MODEL_PATH not found: {mp}")
+        raise RuntimeError("llama_failed")
+
+    safe_prompt = truncate_prompt(prompt)
+    args = [
+        LLAMA_CPP_BIN,
+        "-m", str(mp),
+        "-p", safe_prompt,
+        "-n", "2048",
+        "--temp", "0.2",
+        "-c", str(LLAMA_CTX),
+    ]
+    out = subprocess.run(args, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    if out.returncode != 0:
+        print("llama.cpp error output:\n", out.stdout)
+        raise RuntimeError("llama_failed")
+    return out.stdout
+
+def call_llm(prompt):
+    if PROVIDER == "openai":
+        try:
+            return _call_openai(prompt)
+        except RuntimeError as e:
+            if "openai_error" in str(e) and FALLBACK_PROVIDER == "llama":
+                print("⚠️ OpenAI failed (quota or request). Falling back to llama.cpp…")
+                return _call_llama(prompt)
+            raise
+    elif PROVIDER == "llama":
+        return _call_llama(prompt)
+    else:
+        raise RuntimeError(f"Unknown PROVIDER={PROVIDER}")
+
+# -------- patching --------
+def extract_unified_diff(text):
+    m = re.search(r'(?ms)^--- [^\n]+\n\+\+\+ [^\n]+\n', text)
+    if not m:
+        return None
+    return text[m.start():].strip()
+
+def apply_patch(diff_text):
+    tmp = tempfile.NamedTemporaryFile("w", delete=False, suffix=".patch")
+    tmp.write(diff_text)
+    tmp.close()
+    try:
+        git("add", "-A")
+        run("git diff --staged > .pre_ai_fix.patch || true")
+        run(f"git apply --reject --whitespace=fix {tmp.name}", capture=True)
+        git("add", "-A")
+        run('git commit -m "airysdark-ai: apply automatic fix" || true')
+        return True
+    except Exception as e:
+        print("Patch apply failed:", e)
+        return False
+    finally:
+        os.unlink(tmp.name)
+
+# -------- main --------
+def main():
+    print("== AirysDark-AI Builder (OpenAI → llama fallback) ==")
+    print("Project:", PROJECT_ROOT)
+    print(f"Provider: {PROVIDER}, Model: {OPENAI_MODEL}, Fallback: {FALLBACK_PROVIDER}")
+
+    if not (PROJECT_ROOT / ".git").exists():
+        run("git init")
+        run('git config user.name "airysdark-ai"')
+        run('git config user.email "airysdark-ai@local"')
+        git("add", "-A")
+        run('git commit -m "airysdark-ai: initial snapshot" || true')
+
+    code = run_build()
+    if code == 0:
+        print("✅ Build already succeeds. Nothing to do.")
+        return 0
+
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        print(f"\n== Attempt {attempt}/{MAX_ATTEMPTS} ==")
+        prompt = PROMPT.format(
+            repo_tree=get_repo_tree(),
+            recent_diff=get_recent_diff(),
+            build_cmd=BUILD_CMD,
+            ai_log_tail=AI_LOG_TAIL,
+            build_tail=tail_build_log(AI_LOG_TAIL),
+        )
+        llm_out = call_llm(prompt)
+        diff = extract_unified_diff(llm_out)
+        if not diff:
+            print("LLM did not return a unified diff. Aborting.")
+            break
+
+        print("\n--- Proposed diff (truncated) ---\n")
+        print(diff[:1500])
+        print("\n--- end preview ---\n")
+
+        if not apply_patch(diff):
+            print("Could not apply patch. Stopping.")
+            break
+
+        code = run_build()
+        if code == 0:
+            print("✅ Build fixed!")
+            return 0
+
+    print("❌ Still failing after attempts.")
+    return 1
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/AirysDark-AI_detector.py
+++ b/tools/AirysDark-AI_detector.py
@@ -1,0 +1,791 @@
+#!/usr/bin/env python3
+# AirysDark-AI_detector.py (deep scan + safe YAML)
+#
+# - Walks the entire repo (all subdirs) and reads relevant files.
+# - Folder-name hints (linux/android/windows).
+# - Android deep detection (manifest, Gradle plugin markers, module layout).
+# - CMake content-aware classification (desktop-ish => also flag linux).
+# - Emits PROBE workflows ("AirysDark-AI_prob_<type>.yml") with quoted 'on:' and block-style 'with:'.
+# - Probe workflow fetches tools, computes BUILD_CMD, writes final workflow, pins remote, opens PRs.
+#
+# Types: android, cmake, linux, node, python, rust, dotnet, maven, flutter, go, bazel, scons, ninja, unknown
+
+import os
+import pathlib
+import textwrap
+import sys
+from typing import Iterable, Tuple, List, Set
+
+ROOT = pathlib.Path(os.getenv("PROJECT_DIR", ".")).resolve()
+WF = ROOT / ".github" / "workflows"
+WF.mkdir(parents=True, exist_ok=True)
+
+# ---------- full repo scan ----------
+def scan_all_files() -> List[Tuple[pathlib.Path, pathlib.Path, str]]:
+    out: List[Tuple[pathlib.Path, pathlib.Path, str]] = []
+    for root, dirs, files in os.walk(ROOT):
+        if ".git" in dirs:
+            dirs.remove(".git")
+        for fn in files:
+            ap = pathlib.Path(root) / fn
+            try:
+                rp = ap.relative_to(ROOT)
+            except Exception:
+                rp = ap
+            out.append((ap, rp, fn.lower()))
+    return out
+
+def read_text_lower_safe(path: pathlib.Path) -> str:
+    try:
+        with open(path, "rb") as f:
+            data = f.read()
+        try:
+            return data.decode("utf-8", errors="ignore").lower()
+        except Exception:
+            return data.decode("latin-1", errors="ignore").lower()
+    except Exception:
+        return ""
+
+def any_file_contains(paths: Iterable[pathlib.Path], needles: Iterable[str]) -> bool:
+    needles_l = [n.lower() for n in needles]
+    for p in paths:
+        t = read_text_lower_safe(p)
+        if not t:
+            continue
+        if any(n in t for n in needles_l):
+            return True
+    return False
+
+def collect_dir_name_hints(files_index: List[Tuple[pathlib.Path, pathlib.Path, str]]) -> Set[str]:
+    names: Set[str] = set()
+    for _abs, rel, _fn in files_index:
+        for part in pathlib.Path(rel).parts:
+            names.add(part.lower())
+    return names
+
+# ---------- CMake classifier ----------
+ANDROID_HINTS = (
+    "android", "android_abi", "android_platform", "ndk", "cmake_android",
+    "gradle", "externalnativebuild", "find_library(log)", "log-lib", "loglib",
+)
+DESKTOP_HINTS = (
+    "add_executable", "pkgconfig", "find_package(", "threads", "pthread",
+    "x11", "wayland", "gtk", "qt", "set(cmake_system_name linux",
+)
+
+def cmakelists_flavor(cm_txt: str) -> str:
+    t = cm_txt.lower()
+    if any(h in t for h in ANDROID_HINTS):
+        return "android"
+    if any(h in t for h in DESKTOP_HINTS):
+        return "desktop"
+    return "desktop"
+
+# ---------- Android deep detection ----------
+ANDROID_PLUGIN_MARKERS = (
+    "com.android.application",
+    "com.android.library",
+    'id("com.android.application")',
+    'id("com.android.library")',
+)
+
+def has_android_signals(files_index: List[Tuple[pathlib.Path, pathlib.Path, str]], dir_hints: Set[str]) -> bool:
+    # strong: AndroidManifest anywhere
+    if any(fn == "androidmanifest.xml" for _, _, fn in files_index):
+        return True
+
+    # Gradle files anywhere
+    gradle_files = [
+        abs_p for (abs_p, _rel, fn) in files_index
+        if fn in ("build.gradle", "build.gradle.kts", "settings.gradle", "settings.gradle.kts")
+    ]
+    wrappers = [abs_p for (abs_p, _rel, fn) in files_index if fn == "gradlew"]
+
+    if not gradle_files and not wrappers:
+        return False  # no Gradle at all
+
+    # Android plugin markers inside Gradle files
+    if any_file_contains(gradle_files, ANDROID_PLUGIN_MARKERS):
+        return True
+
+    # Typical Android module structure hints, alongside Gradle
+    rel_paths = [str(rel).lower() for (_abs, rel, _f) in files_index]
+    if any("/src/main/androidmanifest.xml" in rp for rp in rel_paths):
+        return True
+    if any("/res/" in rp or rp.endswith("/res") for rp in rel_paths):
+        return True
+    if any("/src/androidtest" in rp or "/src/test" in rp for rp in rel_paths):
+        return True
+
+    # Folder name "android" anywhere with Gradle present
+    if "android" in dir_hints and (gradle_files or wrappers):
+        return True
+
+    return False
+
+# ---------- detect types ----------
+def detect_types():
+    files_index = scan_all_files()
+    dir_hints   = collect_dir_name_hints(files_index)
+    fnames      = [fn for (_a, _r, fn) in files_index]
+    rels        = [str(rel).lower() for (_a, rel, _f) in files_index]
+
+    types: List[str] = []
+
+    # folder-name hints
+    if "linux" in dir_hints and "linux" not in types: types.append("linux")
+    if "android" in dir_hints and "android" not in types: types.append("android")
+    if "windows" in dir_hints and "windows" not in types: types.append("windows")
+
+    # ANDROID deep
+    if has_android_signals(files_index, dir_hints):
+        if "android" not in types:
+            types.append("android")
+
+    # CMAKE (content-aware)
+    cmake_paths = [abs_p for (abs_p, _rel, fn) in files_index if fn == "cmakelists.txt"]
+    if cmake_paths and "cmake" not in types:
+        types.append("cmake")
+    for p in cmake_paths:
+        txt = read_text_lower_safe(p)
+        if txt and cmakelists_flavor(txt) == "desktop" and "linux" not in types:
+            types.append("linux")
+
+    # LINUX umbrella (make/meson/*.mk)
+    if ("makefile" in fnames) or ("gnumakefile" in fnames) or ("meson.build" in fnames) or any(r.endswith(".mk") for r in rels):
+        if "linux" not in types:
+            types.append("linux")
+
+    # other ecosystems
+    if "package.json" in fnames and "node" not in types:
+        types.append("node")
+    if ("pyproject.toml" in fnames or "setup.py" in fnames) and "python" not in types:
+        types.append("python")
+    if "cargo.toml" in fnames and "rust" not in types:
+        types.append("rust")
+    if any(r.endswith(".sln") or r.endswith(".csproj") or r.endswith(".fsproj") for r in rels) and "dotnet" not in types:
+        types.append("dotnet")
+    if "pom.xml" in fnames and "maven" not in types:
+        types.append("maven")
+    if "pubspec.yaml" in fnames and "flutter" not in types:
+        types.append("flutter")
+    if "go.mod" in fnames and "go" not in types:
+        types.append("go")
+    if any(n in ("workspace", "workspace.bazel", "module.bazel") for n in fnames) or \
+       any(os.path.basename(r) in ("build", "build.bazel") for r in rels):
+        if "bazel" not in types:
+            types.append("bazel")
+    if "sconstruct" in fnames or "sconscript" in fnames:
+        if "scons" not in types:
+            types.append("scons")
+    if "build.ninja" in fnames and "ninja" not in types:
+        types.append("ninja")
+
+    if not types:
+        types.append("unknown")
+
+    # de-dupe preserve order
+    seen, out = set(), []
+    for t in types:
+        if t not in seen:
+            seen.add(t)
+            out.append(t)
+    return out
+
+# ---------- setup snippets ----------
+def setup_steps_inline(ptype: str) -> str:
+    if ptype == "android":
+        return textwrap.dedent("""
+          - uses: actions/setup-java@v4
+            with:
+              distribution: temurin
+              java-version: "17"
+          - uses: android-actions/setup-android@v3
+          - run: yes | sdkmanager --licenses
+          - run: sdkmanager "platform-tools" "platforms;android-34" "build-tools;34.0.0"
+        """)
+    if ptype == "node":
+        return textwrap.dedent("""
+          - uses: actions/setup-node@v4
+            with:
+              node-version: "20"
+        """)
+    if ptype == "rust":
+        return textwrap.dedent("""
+          - uses: dtolnay/rust-toolchain@stable
+          - run: rustc --version && cargo --version
+        """)
+    if ptype == "dotnet":
+        return textwrap.dedent("""
+          - uses: actions/setup-dotnet@v4
+            with:
+              dotnet-version: "8.0.x"
+          - run: dotnet --info
+        """)
+    if ptype == "maven":
+        return textwrap.dedent("""
+          - uses: actions/setup-java@v4
+            with:
+              distribution: temurin
+              java-version: "17"
+          - run: mvn --version
+        """)
+    if ptype == "flutter":
+        return textwrap.dedent("""
+          - uses: subosito/flutter-action@v2
+            with:
+              flutter-version: "3.22.0"
+          - run: flutter --version
+        """)
+    if ptype == "go":
+        return textwrap.dedent("""
+          - uses: actions/setup-go@v5
+            with:
+              go-version: "1.22"
+          - run: go version
+        """)
+    if ptype == "linux":
+        return textwrap.dedent("""
+          - name: Install Meson & Ninja (Linux only)
+            run: |
+              sudo apt-get update
+              sudo apt-get install -y meson ninja-build pkg-config
+        """)
+    if ptype == "bazel":
+        return textwrap.dedent("""
+          - uses: bazelbuild/setup-bazelisk@v3
+        """)
+    if ptype == "scons":
+        return textwrap.dedent("""
+          - name: Install SCons
+            run: |
+              sudo apt-get update
+              sudo apt-get install -y scons
+        """)
+    if ptype == "ninja":
+        return textwrap.dedent("""
+          - name: Ensure Ninja
+            run: |
+              sudo apt-get update
+              sudo apt-get install -y ninja-build
+        """)
+    # cmake/python/unknown: only setup-python is required
+    return ""
+
+PIN_REMOTE_YAML = textwrap.dedent("""\
+      - name: Pin git remote with token (just-in-time)
+        env:
+          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+          REPO_SLUG: ${{ github.repository }}
+        run: |
+          set -euxo pipefail
+          git config --local --name-only --get-regexp '^http\\.https://github\\.com/\\.extraheader$' >/dev/null 2>&1 && \
+            git config --local --unset-all http.https://github.com/.extraheader || true
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git remote set-url origin "https://x-access-token:${BOT_TOKEN}@github.com/${REPO_SLUG}.git"
+          git config --global url."https://x-access-token:${BOT_TOKEN}@github.com/".insteadOf "https://github.com/"
+          git remote -v
+""")
+
+# ---------- PROBE workflow (generic) ----------
+def write_probe_workflow_for_type(ptype: str):
+    setup_inline = setup_steps_inline(ptype)
+
+    tmpl = r"""
+name: AirysDark-AI - Probe __PTYPE_CAP__
+
+'on':
+  workflow_dispatch: {}
+  push:
+    branches:
+      - '**'
+  pull_request: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install requests
+
+      - name: Ensure AirysDark-AI tools (detector, probe, builder)
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p tools
+          BASE_URL="https://raw.githubusercontent.com/AirysDark-AI/AirysDark-AI_builder/main/tools"
+          curl -fL "$BASE_URL/AirysDark-AI_detector.py" -o tools/AirysDark-AI_detector.py
+          curl -fL "$BASE_URL/AirysDark-AI_probe.py"     -o tools/AirysDark-AI_probe.py
+          curl -fL "$BASE_URL/AirysDark-AI_builder.py"  -o tools/AirysDark-AI_builder.py
+          ls -la tools
+__SETUP_INLINE__
+      - name: Probe build command
+        id: probe
+        shell: bash
+        run: |
+          set -euxo pipefail
+          python3 tools/AirysDark-AI_probe.py --type "__PTYPE__" | tee /tmp/probe.out
+          CMD=$(grep -E '^BUILD_CMD=' /tmp/probe.out | sed 's/^BUILD_CMD=//')
+          echo "BUILD_CMD=$CMD" >> "$GITHUB_OUTPUT"
+
+      - name: Generate final workflow .github/workflows/AirysDark-AI___PTYPE__.yml
+        shell: bash
+        env:
+          BUILD_CMD: "${{ steps.probe.outputs.BUILD_CMD }}"
+        run: |
+          set -euo pipefail
+          mkdir -p .github/workflows
+          cat > .github/workflows/AirysDark-AI___PTYPE__.yml <<'YAML'
+          name: AirysDark-AI - __PTYPE_CAP__ (generated)
+
+          'on':
+            workflow_dispatch: {}
+            push:
+              branches:
+                - '**'
+            pull_request: {}
+
+          jobs:
+            build:
+              runs-on: ubuntu-latest
+              permissions:
+                contents: write
+                pull-requests: write
+              steps:
+                - uses: actions/checkout@v4
+                  with:
+                    fetch-depth: 0
+                    persist-credentials: false
+
+                - uses: actions/setup-python@v5
+                  with:
+                    python-version: "3.11"
+                - run: pip install requests
+__SETUP_INLINE__
+                - name: Ensure AirysDark-AI tools (detector, builder)
+                  shell: bash
+                  run: |
+                    set -euo pipefail
+                    mkdir -p tools
+                    BASE_URL="https://raw.githubusercontent.com/AirysDark-AI/AirysDark-AI_builder/main/tools"
+                    [ -f tools/AirysDark-AI_detector.py ] || curl -fL "$BASE_URL/AirysDark-AI_detector.py" -o tools/AirysDark-AI_detector.py
+                    [ -f tools/AirysDark-AI_builder.py ]  || curl -fL "$BASE_URL/AirysDark-AI_builder.py"  -o tools/AirysDark-AI_builder.py
+
+                - name: Build (capture)
+                  id: build
+                  shell: bash
+                  run: |
+                    set -euxo pipefail
+                    CMD="$BUILD_CMD"
+                    echo "BUILD_CMD=$CMD" >> "$GITHUB_OUTPUT"
+                    set +e; bash -lc "$CMD" | tee build.log; EXIT=$?; set -e
+                    echo "EXIT_CODE=$EXIT" >> "$GITHUB_OUTPUT"
+                    [ -s build.log ] || echo "(no build output captured)" > build.log
+                    exit 0
+                  continue-on-error: true
+
+                - name: Upload build log
+                  if: always()
+                  uses: actions/upload-artifact@v4
+                  with:
+                    name: __PTYPE__-build-log
+                    path: build.log
+                    if-no-files-found: warn
+                    retention-days: 7
+
+                # --- AI auto-fix (OpenAI -> llama.cpp) ---
+                - name: Build llama.cpp (CMake, no CURL, in temp)
+                  if: always() && ${{ steps.build.outputs.EXIT_CODE != '0' }}
+                  run: |
+                    set -euxo pipefail
+                    TMP="${{ runner.temp }}"
+                    cd "$TMP"
+                    rm -rf llama.cpp
+                    git clone --depth=1 https://github.com/ggml-org/llama.cpp
+                    cd llama.cpp
+                    cmake -S . -B build -D CMAKE_BUILD_TYPE=Release -DLLAMA_CURL=OFF
+                    cmake --build build -j
+                    echo "LLAMA_CPP_BIN=$PWD/build/bin/llama-cli" >> $GITHUB_ENV
+
+                - name: Fetch GGUF model (TinyLlama)
+                  if: always() && ${{ steps.build.outputs.EXIT_CODE != '0' }}
+                  run: |
+                    mkdir -p models
+                    curl -L -o models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf \
+                      https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf
+
+                - name: Attempt AI auto-fix (OpenAI -> llama fallback)
+                  if: always() && ${{ steps.build.outputs.EXIT_CODE != '0' }}
+                  env:
+                    PROVIDER: openai
+                    FALLBACK_PROVIDER: llama
+                    OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+                    OPENAI_MODEL: ${{ vars.OPENAI_MODEL || 'gpt-4o-mini' }}
+                    MODEL_PATH: models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf
+                    AI_BUILDER_ATTEMPTS: "3"
+                    BUILD_CMD: ${{ steps.build.outputs.BUILD_CMD }}
+                  run: python3 tools/AirysDark-AI_builder.py || true
+
+                - name: Upload AI patch (if any)
+                  if: always()
+                  uses: actions/upload-artifact@v4
+                  with:
+                    name: __PTYPE__-ai-patch
+                    path: .pre_ai_fix.patch
+                    if-no-files-found: ignore
+                    retention-days: 7
+
+                - name: Check for changes
+                  id: diff
+                  run: |
+                    git add -A
+                    if git diff --cached --quiet; then
+                      echo "changed=false" >> "$GITHUB_OUTPUT"
+                    else:
+                      echo "changed=true" >> "$GITHUB_OUTPUT"
+                    fi
+
+                # Pin remote with BOT_TOKEN before creating PR (avoids credential issues)
+                - name: Pin git remote with token (just-in-time)
+                  if: ${{ steps.diff.outputs.changed == 'true' }}
+                  env:
+                    BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+                    REPO_SLUG: ${{ github.repository }}
+                  run: |
+                    set -euxo pipefail
+                    git config --local --name-only --get-regexp '^http\.https://github\.com/\.extraheader$' >/dev/null 2>&1 && \
+                      git config --local --unset-all http.https://github.com/.extraheader || true
+                    git config --global --add safe.directory "$GITHUB_WORKSPACE"
+                    git remote set-url origin "https://x-access-token:${BOT_TOKEN}@github.com/${REPO_SLUG}.git"
+                    git config --global url."https://x-access-token:${BOT_TOKEN}@github.com/".insteadOf "https://github.com/"
+                    git remote -v
+
+                - name: Create PR with AI fixes
+                  if: ${{ steps.diff.outputs.changed == 'true' }}
+                  uses: peter-evans/create-pull-request@v6
+                  with:
+                    token: ${{ secrets.BOT_TOKEN }}
+                    branch: ai/airysdark-ai-autofix-__PTYPE__
+                    commit-message: "chore: AirysDark-AI auto-fix (__PTYPE__)"
+                    title: "AirysDark-AI: automated build fix (__PTYPE__)"
+                    body: |
+                      This PR was opened automatically by a generated workflow after a failed build.
+                      - Build command: ${{ steps.build.outputs.BUILD_CMD }}
+                      - Captured the failing build log
+                      - Proposed a minimal fix via AI
+                      - Committed the changes for review
+                    labels: automation, ci
+          YAML
+
+      # Pin before PR that adds the final workflow
+      - name: Pin git remote with token (just-in-time)
+        env:
+          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+          REPO_SLUG: ${{ github.repository }}
+        run: |
+          set -euxo pipefail
+          git config --local --name-only --get-regexp '^http\.https://github\.com/\.extraheader$' >/dev/null 2>&1 && \
+            git config --local --unset-all http.https://github.com/.extraheader || true
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git remote set-url origin "https://x-access-token:${BOT_TOKEN}@github.com/${REPO_SLUG}.git"
+          git config --global url."https://x-access-token:${BOT_TOKEN}@github.com/".insteadOf "https://github.com/"
+          git remote -v
+
+      - name: Create PR with generated final workflow
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.BOT_TOKEN }}
+          branch: ai/airysdark-ai-workflow-__PTYPE__
+          commit-message: "chore: add AirysDark-AI___PTYPE__ workflow (probed)"
+          title: "AirysDark-AI: add __PTYPE__ workflow (from probe)"
+          body: |
+            This PR adds the final __PTYPE__ AI build workflow, generated by the probe run.
+            - Probed command: ${{ steps.probe.outputs.BUILD_CMD }}
+            - Next: merge this PR, then run \"AirysDark-AI - __PTYPE_CAP__ (generated)\"
+          labels: automation, ci
+""".lstrip("\n")
+
+    setup_block = ""
+    if setup_inline.strip():
+        setup_block = textwrap.indent(setup_inline.rstrip() + "\n", " " * 6)
+
+    yaml = (tmpl
+            .replace("__SETUP_INLINE__", setup_block.rstrip("\n"))
+            .replace("__PTYPE__", ptype)
+            .replace("__PTYPE_CAP__", ptype.capitalize())
+            )
+
+    (WF / f"AirysDark-AI_prob_{ptype}.yml").write_text(yaml)
+    print(f"✅ Generated: AirysDark-AI_prob_{ptype}.yml")
+
+# ---------- Android-specific PROBE writer (kept explicit) ----------
+def write_probe_workflow_for_android():
+    setup_inline = setup_steps_inline("android")
+
+    tmpl = r"""
+name: AirysDark-AI - Probe Android
+
+'on':
+  workflow_dispatch: {}
+  push:
+    branches:
+      - '**'
+  pull_request: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install requests
+
+      - name: Ensure AirysDark-AI tools (detector, probe, builder)
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p tools
+          BASE_URL="https://raw.githubusercontent.com/AirysDark-AI/AirysDark-AI_builder/main/tools"
+          curl -fL "$BASE_URL/AirysDark-AI_detector.py" -o tools/AirysDark-AI_detector.py
+          curl -fL "$BASE_URL/AirysDark-AI_probe.py"     -o tools/AirysDark-AI_probe.py
+          curl -fL "$BASE_URL/AirysDark-AI_builder.py"  -o tools/AirysDark-AI_builder.py
+          ls -la tools
+__SETUP_INLINE__
+      - name: Probe build command (Android)
+        id: probe
+        shell: bash
+        run: |
+          set -euxo pipefail
+          python3 tools/AirysDark-AI_probe.py --type "android" | tee /tmp/probe.out
+          CMD=$(grep -E '^BUILD_CMD=' /tmp/probe.out | sed 's/^BUILD_CMD=//')
+          echo "BUILD_CMD=$CMD" >> "$GITHUB_OUTPUT"
+
+      - name: Generate final workflow .github/workflows/AirysDark-AI_android.yml
+        shell: bash
+        env:
+          BUILD_CMD: "${{ steps.probe.outputs.BUILD_CMD }}"
+        run: |
+          set -euo pipefail
+          mkdir -p .github/workflows
+          cat > .github/workflows/AirysDark-AI_android.yml <<'YAML'
+          name: AirysDark-AI - Android (generated)
+
+          'on':
+            workflow_dispatch: {}
+            push:
+              branches:
+                - '**'
+            pull_request: {}
+
+          jobs:
+            build:
+              runs-on: ubuntu-latest
+              permissions:
+                contents: write
+                pull-requests: write
+              steps:
+                - uses: actions/checkout@v4
+                  with:
+                    fetch-depth: 0
+                    persist-credentials: false
+
+                - uses: actions/setup-python@v5
+                  with:
+                    python-version: "3.11"
+                - run: pip install requests
+
+                # Android SDK / Java
+                - uses: actions/setup-java@v4
+                  with:
+                    distribution: temurin
+                    java-version: "17"
+                - uses: android-actions/setup-android@v3
+                - run: yes | sdkmanager --licenses
+                - run: sdkmanager "platform-tools" "platforms;android-34" "build-tools;34.0.0"
+
+                - name: Ensure AirysDark-AI tools (detector, builder)
+                  shell: bash
+                  run: |
+                    set -euo pipefail
+                    mkdir -p tools
+                    BASE_URL="https://raw.githubusercontent.com/AirysDark-AI/AirysDark-AI_builder/main/tools"
+                    [ -f tools/AirysDark-AI_detector.py ] || curl -fL "$BASE_URL/AirysDark-AI_detector.py" -o tools/AirysDark-AI_detector.py
+                    [ -f tools/AirysDark-AI_builder.py ]  || curl -fL "$BASE_URL/AirysDark-AI_builder.py"  -o tools/AirysDark-AI_builder.py
+
+                - name: Build (capture)
+                  id: build
+                  shell: bash
+                  run: |
+                    set -euxo pipefail
+                    CMD="$BUILD_CMD"
+                    echo "BUILD_CMD=$CMD" >> "$GITHUB_OUTPUT"
+                    set +e; bash -lc "$CMD" | tee build.log; EXIT=$?; set -e
+                    echo "EXIT_CODE=$EXIT" >> "$GITHUB_OUTPUT"
+                    [ -s build.log ] || echo "(no build output captured)" > build.log
+                    exit 0
+                  continue-on-error: true
+
+                - name: Upload build log
+                  if: always()
+                  uses: actions/upload-artifact@v4
+                  with:
+                    name: android-build-log
+                    path: build.log
+                    if-no-files-found: warn
+                    retention-days: 7
+
+                # --- AI auto-fix (OpenAI -> llama.cpp) ---
+                - name: Build llama.cpp (CMake, no CURL, in temp)
+                  if: always() && ${{ steps.build.outputs.EXIT_CODE != '0' }}
+                  run: |
+                    set -euxo pipefail
+                    TMP="${{ runner.temp }}"
+                    cd "$TMP"
+                    rm -rf llama.cpp
+                    git clone --depth=1 https://github.com/ggml-org/llama.cpp
+                    cd llama.cpp
+                    cmake -S . -B build -D CMAKE_BUILD_TYPE=Release -DLLAMA_CURL=OFF
+                    cmake --build build -j
+                    echo "LLAMA_CPP_BIN=$PWD/build/bin/llama-cli" >> $GITHUB_ENV
+
+                - name: Fetch GGUF model (TinyLlama)
+                  if: always() && ${{ steps.build.outputs.EXIT_CODE != '0' }}
+                  run: |
+                    mkdir -p models
+                    curl -L -o models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf \
+                      https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf
+
+                - name: Attempt AI auto-fix (OpenAI -> llama fallback)
+                  if: always() && ${{ steps.build.outputs.EXIT_CODE != '0' }}
+                  env:
+                    PROVIDER: openai
+                    FALLBACK_PROVIDER: llama
+                    OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+                    OPENAI_MODEL: ${{ vars.OPENAI_MODEL || 'gpt-4o-mini' }}
+                    MODEL_PATH: models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf
+                    AI_BUILDER_ATTEMPTS: "3"
+                    BUILD_CMD: ${{ steps.build.outputs.BUILD_CMD }}
+                  run: python3 tools/AirysDark-AI_builder.py || true
+
+                - name: Upload AI patch (if any)
+                  if: always()
+                  uses: actions/upload-artifact@v4
+                  with:
+                    name: android-ai-patch
+                    path: .pre_ai_fix.patch
+                    if-no-files-found: ignore
+                    retention-days: 7
+
+                - name: Check for changes
+                  id: diff
+                  run: |
+                    git add -A
+                    if git diff --cached --quiet; then
+                      echo "changed=false" >> "$GITHUB_OUTPUT"
+                    else:
+                      echo "changed=true" >> "$GITHUB_OUTPUT"
+                    fi
+
+                - name: Pin git remote with token (just-in-time)
+                  if: ${{ steps.diff.outputs.changed == 'true' }}
+                  env:
+                    BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+                    REPO_SLUG: ${{ github.repository }}
+                  run: |
+                    set -euxo pipefail
+                    git config --local --name-only --get-regexp '^http\.https://github\.com/\.extraheader$' >/dev/null 2>&1 && \
+                      git config --local --unset-all http.https://github.com/.extraheader || true
+                    git config --global --add safe.directory "$GITHUB_WORKSPACE"
+                    git remote set-url origin "https://x-access-token:${BOT_TOKEN}@github.com/${REPO_SLUG}.git"
+                    git config --global url."https://x-access-token:${BOT_TOKEN}@github.com/".insteadOf "https://github.com/"
+                    git remote -v
+
+                - name: Create PR with AI fixes
+                  if: ${{ steps.diff.outputs.changed == 'true' }}
+                  uses: peter-evans/create-pull-request@v6
+                  with:
+                    token: ${{ secrets.BOT_TOKEN }}
+                    branch: ai/airysdark-ai-autofix-android
+                    commit-message: "chore: AirysDark-AI auto-fix (android)"
+                    title: "AirysDark-AI: automated build fix (android)"
+                    body: |
+                      This PR was opened automatically by a generated workflow after a failed build.
+                      - Build command: ${{ steps.build.outputs.BUILD_CMD }}
+                      - Captured the failing build log
+                      - Proposed a minimal fix via AI
+                      - Committed the changes for review
+                    labels: automation, ci
+          YAML
+
+      - name: Pin git remote with token (just-in-time)
+        env:
+          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+          REPO_SLUG: ${{ github.repository }}
+        run: |
+          set -euxo pipefail
+          git config --local --name-only --get-regexp '^http\.https://github\.com/\.extraheader$' >/dev/null 2>&1 && \
+            git config --local --unset-all http.https://github.com/.extraheader || true
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git remote set-url origin "https://x-access-token:${BOT_TOKEN}@github.com/${REPO_SLUG}.git"
+          git config --global url."https://x-access-token:${BOT_TOKEN}@github.com/".insteadOf "https://github.com/"
+          git remote -v
+
+      - name: Create PR with generated final workflow
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.BOT_TOKEN }}
+          branch: ai/airysdark-ai-workflow-android
+          commit-message: "chore: add AirysDark-AI_android workflow (probed)"
+          title: "AirysDark-AI: add Android workflow (from probe)"
+          body: |
+            This PR adds the final Android AI build workflow, generated by the probe run.
+            - Probed command: ${{ steps.probe.outputs.BUILD_CMD }}
+            - Next: merge this PR, then run "AirysDark-AI - Android (generated)"
+          labels: automation, ci
+""".lstrip("\n")
+
+    setup_block = ""
+    if setup_inline.strip():
+        setup_block = textwrap.indent(setup_inline.rstrip() + "\n", " " * 6)
+
+    yaml = (tmpl
+            .replace("__SETUP_INLINE__", setup_block.rstrip("\n"))
+            )
+
+    (WF / "AirysDark-AI_prob_android.yml").write_text(yaml)
+    print("✅ Generated: AirysDark-AI_prob_android.yml")
+
+# ---------- main ----------
+def main():
+    types = detect_types()
+    print("Detected types:", ", ".join(types))
+    for t in types:
+        if t == "android":
+            write_probe_workflow_for_android()
+        else:
+            write_probe_workflow_for_type(t)
+    print(f"Done. Generated {len(types)} PROBE workflow(s) in {WF}")
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/AirysDark-AI_probe.py
+++ b/tools/AirysDark-AI_probe.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""
+AirysDark-AI_probe.py
+Figures out the most likely build command for a given project type,
+so the workflow can run the *right* command before invoking the AI fixer.
+
+Usage (GitHub Actions):
+  - name: Probe build command
+    id: probe
+    run: |
+      python3 tools/AirysDark-AI_probe.py --type "${{ matrix.type || inputs.type || 'linux' }}"
+"""
+
+import argparse, os, re, subprocess, sys, shlex
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+ROOT = Path(".").resolve()
+
+def sh(cmd: str, cwd: Path | None = None, check: bool = False) -> tuple[str, int]:
+    p = subprocess.run(cmd, cwd=cwd, shell=True, text=True,
+                       stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    if check and p.returncode != 0:
+        raise subprocess.CalledProcessError(p.returncode, cmd, output=p.stdout)
+    return p.stdout, p.returncode
+
+def scan_all_files() -> List[Tuple[Path, Path, str]]:
+    out: List[Tuple[Path, Path, str]] = []
+    for root, dirs, files in os.walk(ROOT):
+        if ".git" in dirs:
+            dirs.remove(".git")
+        for fn in files:
+            ap = Path(root) / fn
+            try:
+                rp = ap.relative_to(ROOT)
+            except Exception:
+                rp = ap
+            out.append((ap, rp, fn.lower()))
+    return out
+
+def find_first(globs: Iterable[str]) -> Path | None:
+    for pat in globs:
+        for p in ROOT.glob(pat):
+            return p
+    return None
+
+def print_output_var(name: str, val: str):
+    print(f"{name}={val}")
+
+# ---------------- Android ----------------
+def probe_android() -> str:
+    """
+    Strategy:
+      1) find gradlew(s) anywhere
+      2) pick the wrapper whose directory has a settings.gradle(.kts)
+      3) parse settings for modules; prefer :app
+      4) ask Gradle for tasks; prefer assemble/bundle (Debug → Release → build)
+    """
+    wrappers = list(ROOT.glob("**/gradlew"))
+    if not wrappers and (ROOT / "gradlew").exists():
+        wrappers = [ROOT / "gradlew"]
+    if not wrappers:
+        # fallback
+        return "./gradlew assembleDebug --stacktrace"
+
+    # rank wrappers: prefer one with settings + app module present
+    def parse_modules(settings: Path) -> list[str]:
+        if not settings or not settings.exists():
+            return []
+        txt = settings.read_text(errors="ignore")
+        # include(":app", ":feature:home")
+        mods: list[str] = []
+        for m in re.findall(r'include\s*\((.*?)\)', txt, flags=re.S):
+            parts = re.split(r'[,\s]+', m.strip())
+            for p in parts:
+                p = p.strip().strip('"\'')
+
+                if p.startswith(":"):
+                    mods.append(p[1:])
+        # include ':app', ':lib'
+        for m in re.findall(r'include\s+([^\n]+)', txt, flags=re.I):
+            for p in re.split(r'[, \t]+', m.strip()):
+                p = p.strip().strip('"\'')
+
+                if p.startswith(":"):
+                    mods.append(p[1:])
+        # unique, preserve order
+        seen, out = set(), []
+        for mm in mods:
+            if mm and mm not in seen:
+                seen.add(mm)
+                out.append(mm)
+        return out
+
+    def has_app_module(basedir: Path, modules: list[str]) -> bool:
+        for m in modules:
+            for buildfile in ("build.gradle", "build.gradle.kts"):
+                f = basedir / m.replace(":", "/") / buildfile
+                if f.exists():
+                    t = f.read_text(errors="ignore").lower()
+                    if "com.android.application" in t:
+                        return True
+        # common guesses
+        for guess in ("app", "mobile", "android"):
+            for buildfile in ("build.gradle", "build.gradle.kts"):
+                f = basedir / guess / buildfile
+                if f.exists():
+                    t = f.read_text(errors="ignore").lower()
+                    if "com.android.application" in t:
+                        return True
+        return False
+
+    ranked: list[tuple[Path,bool,bool,list[str]]] = []
+    for g in wrappers:
+        d = g.parent
+        settings = None
+        for s in ("settings.gradle", "settings.gradle.kts"):
+            sp = d / s
+            if sp.exists():
+                settings = sp
+                break
+        modules = parse_modules(settings) if settings else []
+        ranked.append((g, settings is not None, has_app_module(d, modules), modules))
+
+    ranked.sort(key=lambda x: (not x[1], not x[2]))  # settings, then app module
+    g, _, _, modules = ranked[0]
+    try:
+        g.chmod(0o755)
+    except Exception:
+        pass
+
+    # query tasks
+    tasks_out, _ = sh(f"./{g.name} -q tasks --all", cwd=g.parent)
+
+    def exists_task(name: str) -> bool:
+        return re.search(rf"(^|\s){re.escape(name)}(\s|$)", tasks_out) is not None
+
+    # candidates
+    base = ["assembleDebug", "bundleDebug", "assembleRelease", "bundleRelease", "build"]
+    module_candidates: list[str] = []
+    for m in modules:
+        module_candidates += [f":{m}:{t}" for t in base]
+    for guess in ("app", "mobile", "android"):
+        module_candidates += [f":{guess}:{t}" for t in base]
+
+    for t in base:
+        if exists_task(t):
+            return f'cd {shlex.quote(str(g.parent))} && ./gradlew {t} --stacktrace'
+    for t in module_candidates:
+        if exists_task(t):
+            return f'cd {shlex.quote(str(g.parent))} && ./gradlew {t} --stacktrace'
+
+    # last resort
+    return f'cd {shlex.quote(str(g.parent))} && ./gradlew assembleDebug --stacktrace'
+
+# ---------------- CMake ----------------
+def probe_cmake() -> str:
+    if (ROOT / "CMakeLists.txt").exists():
+        return "cmake -S . -B build && cmake --build build -j"
+    first = find_first(["**/CMakeLists.txt"])
+    if first:
+        outdir = f'build/{str(first.parent).replace("/", "_")}'
+        return f'cmake -S "{first.parent}" -B "{outdir}" && cmake --build "{outdir}" -j'
+    return "echo 'No CMakeLists.txt found' && exit 1"
+
+# ---------------- Linux (Make/Meson/Ninja) ----------------
+def probe_linux() -> str:
+    # simple Makefile root
+    if (ROOT / "Makefile").exists():
+        return "make -j"
+    mk = find_first(["**/Makefile"])
+    if mk:
+        return f'make -C "{mk.parent}" -j'
+    # Meson/Ninja
+    if (ROOT / "meson.build").exists():
+        return "(meson setup build --wipe || true); meson setup build || true; ninja -C build"
+    mb = find_first(["**/meson.build"])
+    if mb:
+        d = mb.parent
+        return f'(cd "{d}" && (meson setup build --wipe || true); meson setup build || true; ninja -C build)'
+    # Raw Ninja
+    if (ROOT / "build.ninja").exists():
+        return "ninja"
+    bn = find_first(["**/build.ninja"])
+    if bn:
+        return f'cd "{bn.parent}" && ninja'
+    return "echo 'No Makefile/meson.build/build.ninja found' && exit 1"
+
+# ---------------- Other ecosystems ----------------
+def probe_node() -> str:
+    if (ROOT / "package.json").exists():
+        return "npm ci && npm run build --if-present"
+    p = find_first(["**/package.json"])
+    if p:
+        return f'cd "{p.parent}" && npm ci && npm run build --if-present'
+    return "echo 'No package.json found' && exit 1"
+
+def probe_python() -> str:
+    if (ROOT / "pyproject.toml").exists() or (ROOT / "setup.py").exists():
+        return "pip install -e . && (pytest || python -m pytest || true)"
+    p = find_first(["**/pyproject.toml", "**/setup.py"])
+    if p:
+        return f'cd "{p.parent}" && pip install -e . && (pytest || python -m pytest || true)'
+    return "echo 'No python project found' && exit 1"
+
+def probe_rust() -> str:
+    return "cargo build --locked --all-targets --verbose"
+
+def probe_dotnet() -> str:
+    return "dotnet restore && dotnet build -c Release"
+
+def probe_maven() -> str:
+    return "mvn -B package --file pom.xml"
+
+def probe_flutter() -> str:
+    return "flutter build apk --debug"
+
+def probe_go() -> str:
+    return "go build ./..."
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--type", required=True,
+                    choices=["android","cmake","linux","node","python","rust","dotnet","maven","flutter","go","unknown"])
+    args = ap.parse_args()
+
+    if args.type == "android": cmd = probe_android()
+    elif args.type == "cmake": cmd = probe_cmake()
+    elif args.type == "linux": cmd = probe_linux()
+    elif args.type == "node": cmd = probe_node()
+    elif args.type == "python": cmd = probe_python()
+    elif args.type == "rust": cmd = probe_rust()
+    elif args.type == "dotnet": cmd = probe_dotnet()
+    elif args.type == "maven": cmd = probe_maven()
+    elif args.type == "flutter": cmd = probe_flutter()
+    elif args.type == "go": cmd = probe_go()
+    else: cmd = "echo 'No build system detected' && exit 1"
+
+    print_output_var("BUILD_CMD", cmd)
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This PR adds one **PROBE** workflow per detected build type.

How to proceed:
1) Merge this PR.
2) Run the desired "AirysDark-AI — Probe <Type>" workflow from Actions.
   - It will scan the entire repo, pick the correct BUILD_CMD.
   - It will then generate the final AI build workflow `.github/workflows/AirysDark-AI_<type>.yml`
     and open a second PR with that workflow.
3) Merge the second PR to enable the final build+AI workflow for that type.

Notes:
- These probe workflows use the canonical tools:
  https://github.com/AirysDark-AI/AirysDark-AI_builder/tree/main/tools
- Ensure you set `BOT_TOKEN` (a PAT with `repo` + `workflow` scopes) in repo Secrets.