### PR TITLE
AirysDark-AI: add single PROB workflow + tools

### DIFF
--- a/.github/workflows/AirysDark-AI_prob.yml
+++ b/.github/workflows/AirysDark-AI_prob.yml
@@ -1,0 +1,83 @@
+name: AirysDark-AI - Probe (LLM builds workflow)
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# Set TARGET to one of the detected types: android, linux, cmake, node, python, rust, dotnet, maven, flutter, go
+env:
+  TARGET: "__SET_ME__"
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (no credentials)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Verify tools exist (added by detector PR)
+        shell: bash
+        run: |
+          set -euxo pipefail
+          test -f tools/AirysDark-AI_prob.py
+          test -f tools/AirysDark-AI_builder.py
+          ls -la tools
+          echo "TARGET=$TARGET"
+
+      - name: Run repo probe (AI-assisted)
+        shell: bash
+        env:
+          TARGET: ${{ env.TARGET }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}   # optional
+          OPENAI_MODEL: ${{ vars.OPENAI_MODEL || 'gpt-4o-mini' }}
+        run: |
+          set -euxo pipefail
+          python3 tools/AirysDark-AI_prob.py
+
+      - name: Upload probe artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: airysdark-ai-probe-artifacts
+          if-no-files-found: warn
+          retention-days: 7
+          path: |
+            tools/airysdark_ai_prob_report.json
+            tools/airysdark_ai_prob_report.log
+            tools/airysdark_ai_build_ai_response.txt
+            pr_body_build.md
+            .github/workflows/AirysDark-AI_build.yml
+
+      - name: Stage generated build workflow
+        id: diff
+        shell: bash
+        run: |
+          set -euxo pipefail
+          git add -A
+          if git diff --cached --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else:
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open PR with generated build workflow
+        if: steps.diff.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.BOT_TOKEN }}
+          branch: ai/airysdark-ai-build
+          commit-message: "chore: add AirysDark-AI_build.yml (from probe)"
+          title: "AirysDark-AI: add build workflow (from probe)"
+          body-path: pr_body_build.md
+          labels: "automation, ci"

--- a/tools/AirysDark-AI_prob.py
+++ b/tools/AirysDark-AI_prob.py
@@ -379,7 +379,7 @@ __SETUP__
             - Committed the changes for review
           labels: "automation, ci"
 """
-    """.lstrip("\n")
+    ).lstrip("\n")
 
     setup_block = ""
     if setup.strip():
@@ -445,6 +445,7 @@ def build_ai_prompt(context: dict, target: str, build_cmd: str) -> str:
 
     Partial file list (first 200):
     {files_list}
+    """)
 
 # ---------------- Main ----------------
 


### PR DESCRIPTION
### AirysDark-AI: detector results

**Detected build types:**
- linux
- android
- cmake

**Next steps:**
1. Edit `.github/workflows/AirysDark-AI_prob.yml` and set **env.TARGET** (e.g. `android`, `linux`, `cmake`).
2. Merge this PR.
3. Manually run **AirysDark-AI - Probe (LLM builds workflow)** from the Actions tab.
